### PR TITLE
syntax: introduce `const` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,13 @@ through numeric operations, or explicitely, e.g. by invoking functions such as
 
 Variable names must start with a letter or an underscore and may only contain
 the characters `A`..`Z`, `a`..`z`, `0`..`9` or `_`. By prefixing a variable
-name with the keyword `let`, it is declared in the local function scope only
+name with the keyword `let`, it is declared in the local block scope only
 and not visible outside anymore.
+
+Variables may also be declared using the `const` keyword. Such variables follow
+the same scoping rules as `let` declared ones but they cannot be modified after
+they have been declared. Any attempt to do so will result in a syntax error
+during compilation.
 
 ```javascript
 {%
@@ -171,6 +176,15 @@ and not visible outside anymore.
 
   print(a, "\n");  // outputs "2"
   print(b, "\n");  // outputs nothing
+
+  const c = 3;
+  print(c, "\n");  // outputs "3"
+
+  c = 4;           // raises syntax error
+  c++;             // raises syntax error
+
+  const d;         // raises syntax error, const variables must
+                   // be initialized at declaration time
 
 %}
 ```

--- a/compiler.h
+++ b/compiler.h
@@ -76,12 +76,14 @@ typedef struct {
 	ssize_t depth;
 	size_t from;
 	bool captured;
+	bool constant;
 } uc_local;
 
 typedef struct {
 	uc_value_t *name;
 	size_t index;
 	bool local;
+	bool constant;
 } uc_upval;
 
 uc_declare_vector(uc_locals, uc_local);

--- a/lexer.c
+++ b/lexer.c
@@ -152,6 +152,7 @@ static const struct keyword reserved_words[] = {
 	{ TK_WHILE,		"while", 5, { 0 } },
 	{ TK_BREAK,		"break", 5, { 0 } },
 	{ TK_CATCH,		"catch", 5, { 0 } },
+	{ TK_CONST,		"const", 5, { 0 } },
 	{ TK_BOOL,		"false", 5, { .b = false } },
 	{ TK_BOOL,		"true",  4, { .b = true } },
 	{ TK_ELIF,		"elif",  4, { 0 } },

--- a/lexer.h
+++ b/lexer.h
@@ -104,6 +104,7 @@ typedef enum {
 	TK_NULL,
 	TK_THIS,
 	TK_DELETE,
+	TK_CONST,
 
 	TK_EOF,
 	TK_ERROR


### PR DESCRIPTION
Introduce support for declaring constant variables through the `const`
keyword. Variables declared with `const` follow the same scoping rules
as `let` declared ones.

In contrast to normal variables, `const` ones may not be assigned to
after their declaration. Any attempt to do so will result in a syntax
error during compilation.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>