### PR TITLE
ubus: add support for async requests

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -250,6 +250,7 @@ struct uc_vm {
 	uc_upvalref_t *open_upvals;
 	uc_parse_config_t *config;
 	uc_value_t *globals;
+	uc_value_t *registry;
 	uc_source_t *sources;
 	uc_weakref_t values;
 	uc_resource_types_t restypes;

--- a/include/ucode/vm.h
+++ b/include/ucode/vm.h
@@ -119,6 +119,11 @@ void uc_vm_free(uc_vm_t *vm);
 uc_value_t *uc_vm_scope_get(uc_vm_t *vm);
 void uc_vm_scope_set(uc_vm_t *vm, uc_value_t *ctx);
 
+bool uc_vm_registry_exists(uc_vm_t *vm, const char *key);
+uc_value_t *uc_vm_registry_get(uc_vm_t *vm, const char *key);
+void uc_vm_registry_set(uc_vm_t *vm, const char *key, uc_value_t *value);
+bool uc_vm_registry_delete(uc_vm_t *vm, const char *key);
+
 void uc_vm_stack_push(uc_vm_t *vm, uc_value_t *value);
 uc_value_t *uc_vm_stack_pop(uc_vm_t *vm);
 uc_value_t *uc_vm_stack_peek(uc_vm_t *vm, size_t offset);

--- a/types.c
+++ b/types.c
@@ -2078,6 +2078,7 @@ ucv_gc_common(uc_vm_t *vm, bool final)
 	if (!final) {
 		/* mark reachable objects */
 		ucv_gc_mark(vm->globals);
+		ucv_gc_mark(vm->registry);
 		ucv_gc_mark(vm->exception.stacktrace);
 
 		for (i = 0; i < vm->callframes.count; i++) {

--- a/vm.c
+++ b/vm.c
@@ -2480,3 +2480,34 @@ uc_vm_trace_set(uc_vm_t *vm, uint32_t level)
 {
 	vm->trace = level;
 }
+
+bool
+uc_vm_registry_exists(uc_vm_t *vm, const char *key)
+{
+	bool exists;
+
+	ucv_object_get(vm->registry, key, &exists);
+
+	return exists;
+}
+
+uc_value_t *
+uc_vm_registry_get(uc_vm_t *vm, const char *key)
+{
+	return ucv_object_get(vm->registry, key, NULL);
+}
+
+void
+uc_vm_registry_set(uc_vm_t *vm, const char *key, uc_value_t *value)
+{
+	if (!vm->registry)
+		vm->registry = ucv_object_new(vm);
+
+	ucv_object_add(vm->registry, key, value);
+}
+
+bool
+uc_vm_registry_delete(uc_vm_t *vm, const char *key)
+{
+	return ucv_object_delete(vm->registry, key);
+}


### PR DESCRIPTION
Introduce a new ubus.defer() method which initiates asynchroneous requests
and invokes the completion callback passed as 4th argument once the reply
is received.

This allows multiplexing mutliple ubus requests with the same ucode VM
context / the same uloop event loop.

In case the ucode context is not running under an active uloop, the ubus
module will spawn uloop itself once the first asynchroneous request is
launched and terminate the loop once all pending requests finished.