### PR TITLE
treewide: rework numeric value handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ include(CheckFunctionExists)
 include(CheckSymbolExists)
 
 PROJECT(ucode C)
-ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -ffunction-sections -D_GNU_SOURCE)
+ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -ffunction-sections -fwrapv -D_GNU_SOURCE)
 
 IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
 	ADD_DEFINITIONS(-Wextra -Werror=implicit-function-declaration)
@@ -64,6 +64,11 @@ TARGET_LINK_LIBRARIES(ucode libucode ${json})
 CHECK_FUNCTION_EXISTS(dlopen DLOPEN_FUNCTION_EXISTS)
 IF (NOT DLOPEN_FUNCTION_EXISTS)
   TARGET_LINK_LIBRARIES(libucode dl)
+ENDIF()
+
+CHECK_FUNCTION_EXISTS(fmod FMOD_FUNCTION_EXISTS)
+IF (NOT FMOD_FUNCTION_EXISTS)
+  TARGET_LINK_LIBRARIES(libucode m)
 ENDIF()
 
 SET(CMAKE_REQUIRED_LIBRARIES json-c)

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -372,24 +372,46 @@ void ucv_to_stringbuf_formatted(uc_vm_t *, uc_stringbuf_t *, uc_value_t *, size_
 
 uc_type_t ucv_cast_number(uc_value_t *, int64_t *, double *);
 
+uc_value_t *ucv_to_number(uc_value_t *);
+
 static inline double
 ucv_to_double(uc_value_t *v)
 {
-	int64_t n;
+	uc_value_t *nv;
 	double d;
 
-	return (ucv_cast_number(v, &n, &d) == UC_DOUBLE) ? d : (double)n;
+	nv = ucv_to_number(v);
+	d = ucv_double_get(nv);
+	ucv_put(nv);
+
+	return d;
 }
 
 static inline int64_t
 ucv_to_integer(uc_value_t *v)
 {
+	uc_value_t *nv;
 	int64_t n;
-	double d;
 
-	return (ucv_cast_number(v, &n, &d) == UC_DOUBLE) ? (int64_t)d : n;
+	nv = ucv_to_number(v);
+	n = ucv_int64_get(nv);
+	ucv_put(nv);
+
+	return n;
 }
 
+static inline uint64_t
+ucv_to_unsigned(uc_value_t *v)
+{
+	uc_value_t *nv;
+	uint64_t u;
+
+	nv = ucv_to_number(v);
+	u = ucv_uint64_get(nv);
+	ucv_put(nv);
+
+	return u;
+}
 
 static inline bool
 ucv_is_callable(uc_value_t *uv)
@@ -437,7 +459,7 @@ ucv_is_scalar(uc_value_t *uv)
 bool ucv_is_equal(uc_value_t *, uc_value_t *);
 bool ucv_is_truish(uc_value_t *);
 
-bool ucv_compare(int, uc_value_t *, uc_value_t *);
+bool ucv_compare(int, uc_value_t *, uc_value_t *, int *);
 
 uc_value_t *ucv_key_get(uc_vm_t *, uc_value_t *, uc_value_t *);
 uc_value_t *ucv_key_set(uc_vm_t *, uc_value_t *, uc_value_t *, uc_value_t *);

--- a/include/ucode/vallist.h
+++ b/include/ucode/vallist.h
@@ -41,6 +41,8 @@ typedef enum {
 	TAG_PTR = 6
 } uc_value_type_t;
 
+uc_value_t *uc_number_parse(const char *buf, char **end);
+
 void uc_vallist_init(uc_value_list_t *list);
 void uc_vallist_free(uc_value_list_t *list);
 

--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -69,29 +69,14 @@ set_error(int errcode, const char *fmt, ...) {
 static bool
 uc_nl_parse_u32(uc_value_t *val, uint32_t *n)
 {
-	uc_type_t t;
-	int64_t i;
-	double d;
+	uint64_t u;
 
-	t = ucv_cast_number(val, &i, &d);
+	u = ucv_to_unsigned(val);
 
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < 0 || d > UINT32_MAX)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < 0 || i > UINT32_MAX)
+	if (errno != 0 || u > UINT32_MAX)
 		return false;
 
-	*n = (uint32_t)i;
+	*n = (uint32_t)u;
 
 	return true;
 }
@@ -99,26 +84,11 @@ uc_nl_parse_u32(uc_value_t *val, uint32_t *n)
 static bool
 uc_nl_parse_s32(uc_value_t *val, uint32_t *n)
 {
-	uc_type_t t;
 	int64_t i;
-	double d;
 
-	t = ucv_cast_number(val, &i, &d);
+	i = ucv_to_integer(val);
 
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < INT32_MIN || d > INT32_MAX)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < INT32_MIN || i > INT32_MAX)
+	if (errno != 0 || i < INT32_MIN || i > INT32_MAX)
 		return false;
 
 	*n = (uint32_t)i;
@@ -129,37 +99,9 @@ uc_nl_parse_s32(uc_value_t *val, uint32_t *n)
 static bool
 uc_nl_parse_u64(uc_value_t *val, uint64_t *n)
 {
-	uc_type_t t;
-	int64_t i;
-	double d;
+	*n = ucv_to_unsigned(val);
 
-	if (ucv_type(val) == UC_INTEGER) {
-		*n = ucv_uint64_get(val);
-
-		return true;
-	}
-
-	t = ucv_cast_number(val, &i, &d);
-
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < 0)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < 0)
-		return false;
-
-	*n = (uint64_t)i;
-
-	return true;
+	return (errno == 0);
 }
 
 static bool

--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -97,29 +97,14 @@ typedef struct {
 static bool
 uc_nl_parse_u32(uc_value_t *val, uint32_t *n)
 {
-	uc_type_t t;
-	int64_t i;
-	double d;
+	uint64_t u;
 
-	t = ucv_cast_number(val, &i, &d);
+	u = ucv_to_unsigned(val);
 
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < 0 || d > UINT32_MAX)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < 0 || i > UINT32_MAX)
+	if (errno != 0 || u > UINT32_MAX)
 		return false;
 
-	*n = (uint32_t)i;
+	*n = (uint32_t)u;
 
 	return true;
 }
@@ -127,26 +112,11 @@ uc_nl_parse_u32(uc_value_t *val, uint32_t *n)
 static bool
 uc_nl_parse_s32(uc_value_t *val, uint32_t *n)
 {
-	uc_type_t t;
 	int64_t i;
-	double d;
 
-	t = ucv_cast_number(val, &i, &d);
+	i = ucv_to_integer(val);
 
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < INT32_MIN || d > INT32_MAX)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < INT32_MIN || i > INT32_MAX)
+	if (errno != 0 || i < INT32_MIN || i > INT32_MAX)
 		return false;
 
 	*n = (uint32_t)i;
@@ -157,37 +127,9 @@ uc_nl_parse_s32(uc_value_t *val, uint32_t *n)
 static bool
 uc_nl_parse_u64(uc_value_t *val, uint64_t *n)
 {
-	uc_type_t t;
-	int64_t i;
-	double d;
+	*n = ucv_to_unsigned(val);
 
-	if (ucv_type(val) == UC_INTEGER) {
-		*n = ucv_uint64_get(val);
-
-		return true;
-	}
-
-	t = ucv_cast_number(val, &i, &d);
-
-	if (t == UC_DOUBLE) {
-		if (isnan(d) || d < 0)
-			return false;
-
-		i = (int64_t)d;
-
-		if (d - i > 0)
-			return false;
-	}
-	else if (errno != 0) {
-		return false;
-	}
-
-	if (i < 0)
-		return false;
-
-	*n = (uint64_t)i;
-
-	return true;
+	return (errno == 0);
 }
 
 static const char *

--- a/tests/custom/00_syntax/10_numeric_literals
+++ b/tests/custom/00_syntax/10_numeric_literals
@@ -12,7 +12,7 @@ Special values: Infinity, Infinity, NaN, NaN
 Minimum values: -9223372036854775808, -1.79769e+308
 Maximum values: 9223372036854775807, 1.79769e+308
 Minimum truncation: -9223372036854775808, -Infinity
-Maximum truncation: 9223372036854775807, Infinity
+Maximum truncation: 18446744073709551615, Infinity
 -- End --
 
 -- Testcase --
@@ -21,6 +21,6 @@ Float literals: {{ 10. }}, {{ 10.3 }}, {{ 123.456e-67 }}, {{ 0x10.1 }}
 Special values: {{ Infinity }}, {{ 1 / 0 }}, {{ NaN }}, {{ "x" / 1 }}
 Minimum values: {{ -9223372036854775808 }}, {{ -1.7976931348623158e+308 }}
 Maximum values: {{ 9223372036854775807 }}, {{ 1.7976931348623158e+308 }}
-Minimum truncation: {{ -10000000000000000000 }}, {{ -1.0e309 }}
-Maximum truncation: {{ 10000000000000000000 }}, {{ 1.0e309 }}
+Minimum truncation: {{ -100000000000000000000 }}, {{ -1.0e309 }}
+Maximum truncation: {{ 100000000000000000000 }}, {{ 1.0e309 }}
 -- End --

--- a/tests/custom/01_arithmetic/02_modulo
+++ b/tests/custom/01_arithmetic/02_modulo
@@ -1,32 +1,31 @@
-The utpl language supports modulo divisions, however they're only defined
-for integer values.
+The ucode language supports modulo divisions.
 
 -- Expect stdout --
 If both operands are integers or convertible to integers,
-the modulo division yields the remainder:
+the modulo division yields the remaining integer value:
 10 % 4 = 2
 "10" % 4 = 2
 10 % "4" = 2
 "10" % "4" = 2
 
 If either operand is a double value, the modulo operation
-yields NaN:
-10.0 % 4 = NaN
-10 % 4.0 = NaN
-"10.0" % 4 = NaN
+yields the remaining value as calculated by fmod(3):
+10.2 % 4 = 2.2
+10 % 4.3 = 1.4
+"10.4" % 4 = 2.4
 -- End --
 
 -- Testcase --
 If both operands are integers or convertible to integers,
-the modulo division yields the remainder:
+the modulo division yields the remaining integer value:
 10 % 4 = {{ 10 % 4 }}
 "10" % 4 = {{ "10" % 4 }}
 10 % "4" = {{ 10 % 4 }}
 "10" % "4" = {{ "10" % "4" }}
 
 If either operand is a double value, the modulo operation
-yields NaN:
-10.0 % 4 = {{ 10.0 % 4 }}
-10 % 4.0 = {{ 10 % 4.0 }}
-"10.0" % 4 = {{ "10.0" % 4 }}
+yields the remaining value as calculated by fmod(3):
+10.2 % 4 = {{ 10.2 % 4 }}
+10 % 4.3 = {{ 10 % 4.3 }}
+"10.4" % 4 = {{ "10.4" % 4 }}
 -- End --

--- a/tests/custom/01_arithmetic/03_bitwise
+++ b/tests/custom/01_arithmetic/03_bitwise
@@ -1,5 +1,7 @@
-Utpl implements C-style bitwise operations. One detail is that these operations
-coerce their operands to signed 64bit integer values internally.
+Ucode implements C-style bitwise operations. One detail is that these operations
+coerce their operands to 64bit integer values internally. If both operands are
+positive, unsigned 64bit semantics are used. If one of the operands is negative,
+both are converted to signed 64bit numbers.
 
 -- Expect stdout --
 Left shift:
@@ -23,8 +25,8 @@ Bitwise or:
 120.3 | 54.3 = 126
 
 Complement:
-~0 = -1
-~10.4 = -11
+~0 = 18446744073709551615
+~10.4 = 18446744073709551605
 -- End --
 
 -- Testcase --

--- a/tests/custom/01_arithmetic/05_overflow
+++ b/tests/custom/01_arithmetic/05_overflow
@@ -1,0 +1,54 @@
+For integers, the ucode VM tries to perform unsigned 64bit arithmetic internally
+if both operands are positive or if the result is guaranteed to be positive.
+
+In all other cases, calculations are performed using signed 64bit arithmetic
+with wrap arounds using twos-complement representation.
+
+Due to this, the minimum and maximum representable values depend on the values
+of the involved operands.
+
+-- Testcase --
+Unsigned additions roll over back to zero:
+{{ 18446744073709551615 + 1 }}
+
+Unsigned multiplications roll over back to zero:
+{{ 9223372036854775808 * 2 }}
+
+Signed additions roll over at INT64_MIN/INT64_MAX:
+{{ -9223372036854775808 + -1 }}
+
+Signed multiplications roll over back to INT64_MIN:
+{{ 18446744073709551615 * -1 }}
+
+Multiplicating two negative operands yields an unsigned result.
+{{ -9223372036854775807 * -2 }}
+
+Signed calculations yielding positive results are promoted to unsigned.
+{{ -9223372036854775808 + 9223372036854775808 + -9223372036854775807 * -2 }}
+
+Substractions roll over to INT64_MAX on underflow:
+{{ 0 - 9223372036854775809 }}
+-- End --
+
+-- Expect stdout --
+Unsigned additions roll over back to zero:
+0
+
+Unsigned multiplications roll over back to zero:
+0
+
+Signed additions roll over at INT64_MIN/INT64_MAX:
+9223372036854775807
+
+Signed multiplications roll over back to INT64_MIN:
+-9223372036854775807
+
+Multiplicating two negative operands yields an unsigned result.
+18446744073709551614
+
+Signed calculations yielding positive results are promoted to unsigned.
+18446744073709551614
+
+Substractions roll over to INT64_MAX on underflow:
+9223372036854775807
+-- End --


### PR DESCRIPTION
 - Parse integer literals as unsigned numeric values in order to be able
   to represent the entire unsigned 64bit value range

 - Stop parsing minus-prefixed integer literals as negative numbers but
   treat them as separate minus operator followed by a positive integer
   instead

 - Only store unsigned numeric constants in bytecode

 - Rework numeric comparison logic to be able to handle full 64bit
   unsigned integers

 - If possible, yield unsigned 64 bit results for additions

 - Simplify numeric value conversion API

 - Compile code with -fwrapv for defined signed overflow semantics

Signed-off-by: Jo-Philipp Wich <jo@mein.io>