### PR TITLE
lib: implement uniq() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,3 +1254,16 @@ If a non-string argument is given, the function returns `null`.
 b64enc("This is a test");         // "VGhpcyBpcyBhIHRlc3Q="
 b64enc(123);                      // null
 ```
+
+#### 6.64. `uniq(array)`
+
+Returns a new array containing all unique values of the given input
+array. The order is preserved, that is subsequent duplicate values
+are simply skipped.
+
+If a non-array argument is given, the function returns `null`.
+
+```javascript
+uniq([ 1, true, "foo", 2, true, "bar", "foo" ]); // [ 1, true, "foo", 2, "bar" ]
+uniq("test");                                    // null
+```


### PR DESCRIPTION
The uniq() function allows extracting all unique values from a given input
array in an efficient manner. It is roughly equivalent to the following
ucode idiom:

    let seen = {}
    let unique = filter(array, item => !seen[item]++);

In contrast to the code above, `uniq()` does not rely on implicit
stringification of item values but performs strict equality tests internally.

If equivalence of stringified results is desired, the following code can
be used:

    let unique = uniq(map(array, item => "" + item));

Signed-off-by: Jo-Philipp Wich <jo@mein.io>