### PR TITLE
Introduce ucode precompilation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ ADD_DEFINITIONS(-Wmissing-declarations -Wno-error=unused-variable -Wno-unused-pa
 
 INCLUDE_DIRECTORIES(include)
 
+OPTION(COMPILE_SUPPORT "Support compilation from source" ON)
+
+IF(NOT COMPILE_SUPPORT)
+  ADD_DEFINITIONS(-DNO_COMPILE)
+ENDIF()
+
 OPTION(FS_SUPPORT "Filesystem plugin support" ON)
 OPTION(MATH_SUPPORT "Math plugin support" ON)
 OPTION(UBUS_SUPPORT "Ubus plugin support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ IF(JSONC_FOUND)
   INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
 ENDIF()
 
-SET(UCODE_SOURCES lexer.c lib.c vm.c chunk.c vallist.c compiler.c source.c types.c)
+SET(UCODE_SOURCES lexer.c lib.c vm.c chunk.c vallist.c compiler.c source.c types.c program.c)
 ADD_LIBRARY(libucode SHARED ${UCODE_SOURCES})
 SET(SOVERSION 0 CACHE STRING "Override ucode library version")
 SET_TARGET_PROPERTIES(libucode PROPERTIES OUTPUT_NAME ucode SOVERSION ${SOVERSION})

--- a/chunk.c
+++ b/chunk.c
@@ -45,7 +45,6 @@ uc_chunk_init(uc_chunk_t *chunk)
 	chunk->debuginfo.variables.count = 0;
 	chunk->debuginfo.variables.entries = NULL;
 
-	uc_vallist_init(&chunk->constants);
 	uc_vallist_init(&chunk->debuginfo.varnames);
 }
 
@@ -54,7 +53,6 @@ uc_chunk_free(uc_chunk_t *chunk)
 {
 	uc_vector_clear(chunk);
 	uc_vector_clear(&chunk->ehranges);
-	uc_vallist_free(&chunk->constants);
 
 	uc_vector_clear(&chunk->debuginfo.offsets);
 	uc_vector_clear(&chunk->debuginfo.variables);
@@ -134,18 +132,6 @@ uc_chunk_pop(uc_chunk_t *chunk)
 	else {
 		offsets->count--;
 	}
-}
-
-uc_value_t *
-uc_chunk_get_constant(uc_chunk_t *chunk, size_t idx)
-{
-	return uc_vallist_get(&chunk->constants, idx);
-}
-
-ssize_t
-uc_chunk_add_constant(uc_chunk_t *chunk, uc_value_t *val)
-{
-	return uc_vallist_add(&chunk->constants, val);
 }
 
 size_t

--- a/compiler.c
+++ b/compiler.c
@@ -2901,6 +2901,22 @@ uc_compile(uc_parse_config_t *config, uc_source_t *source, char **errp)
 
 		break;
 
+	case UC_SOURCE_TYPE_PRECOMPILED:
+		prog = uc_program_from_file(source->fp, errp);
+
+		if (prog) {
+			fn = uc_program_entry(prog);
+
+			if (!fn) {
+				if (errp)
+					xasprintf(errp, "Program file contains no entry function\n");
+
+				uc_program_free(prog);
+			}
+		}
+
+		break;
+
 	default:
 		if (errp)
 			xasprintf(errp, "Unrecognized source type\n");

--- a/compiler.c
+++ b/compiler.c
@@ -483,8 +483,7 @@ uc_compiler_set_u32(uc_compiler_t *compiler, size_t off, uint32_t n)
 static size_t
 uc_compiler_emit_constant(uc_compiler_t *compiler, size_t srcpos, uc_value_t *val)
 {
-	uc_chunk_t *chunk = uc_compiler_current_chunk(compiler);
-	size_t cidx = uc_chunk_add_constant(chunk, val);
+	size_t cidx = uc_program_add_constant(compiler->program, val);
 
 	uc_compiler_emit_insn(compiler, srcpos, I_LOAD);
 	uc_compiler_emit_u32(compiler, 0, cidx);
@@ -495,8 +494,7 @@ uc_compiler_emit_constant(uc_compiler_t *compiler, size_t srcpos, uc_value_t *va
 static size_t
 uc_compiler_emit_regexp(uc_compiler_t *compiler, size_t srcpos, uc_value_t *val)
 {
-	uc_chunk_t *chunk = uc_compiler_current_chunk(compiler);
-	size_t cidx = uc_chunk_add_constant(chunk, val);
+	size_t cidx = uc_program_add_constant(compiler->program, val);
 
 	uc_compiler_emit_insn(compiler, srcpos, I_LREXP);
 	uc_compiler_emit_u32(compiler, 0, cidx);
@@ -1086,7 +1084,7 @@ uc_compiler_emit_variable_rw(uc_compiler_t *compiler, uc_value_t *varname, uc_to
 			((sub_insn & 0xff) << 24) | idx);
 	}
 	else {
-		idx = uc_chunk_add_constant(uc_compiler_current_chunk(compiler), varname);
+		idx = uc_program_add_constant(compiler->program, varname);
 		insn = sub_insn ? I_UVAR : (type ? I_SVAR : I_LVAR);
 
 		uc_compiler_emit_insn(compiler, compiler->parser->prev.pos, insn);
@@ -1195,8 +1193,7 @@ uc_compiler_compile_arrowfn(uc_compiler_t *compiler, uc_value_t *args, bool rest
 
 	if (fn)
 		uc_compiler_set_u32(compiler, load_off,
-			uc_chunk_add_constant(uc_compiler_current_chunk(compiler),
-				&fn->header));
+			uc_program_add_constant(compiler->program, &fn->header));
 
 	return true;
 }
@@ -1635,8 +1632,7 @@ uc_compiler_compile_function(uc_compiler_t *compiler)
 
 	if (fn)
 		uc_compiler_set_u32(compiler, load_off,
-			uc_chunk_add_constant(uc_compiler_current_chunk(compiler),
-				&fn->header));
+			uc_program_add_constant(compiler->program, &fn->header));
 
 	/* if a local variable of the same name already existed, overwrite its value
 	 * with the compiled function here */

--- a/include/ucode/chunk.h
+++ b/include/ucode/chunk.h
@@ -28,8 +28,6 @@ void uc_chunk_init(uc_chunk_t *chunk);
 void uc_chunk_free(uc_chunk_t *chunk);
 size_t uc_chunk_add(uc_chunk_t *chunk, uint8_t byte, size_t line);
 
-ssize_t uc_chunk_add_constant(uc_chunk_t *chunk, uc_value_t *value);
-uc_value_t *uc_chunk_get_constant(uc_chunk_t *chunk, size_t idx);
 void uc_chunk_pop(uc_chunk_t *chunk);
 
 size_t uc_chunk_debug_get_srcpos(uc_chunk_t *chunk, size_t off);

--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -116,6 +116,7 @@ typedef struct uc_compiler {
 	uc_exprstack_t *exprstack;
 	uc_value_t *function;
 	uc_parser_t *parser;
+	uc_program_t *program;
 	size_t scope_depth, current_srcpos, last_insn;
 } uc_compiler_t;
 

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -31,4 +31,9 @@ uc_value_t *uc_program_function_load(uc_program_t *, size_t);
 uc_value_t *uc_program_get_constant(uc_program_t *, size_t);
 ssize_t uc_program_add_constant(uc_program_t *, uc_value_t *);
 
+void uc_program_to_file(uc_program_t *, FILE *, bool);
+uc_program_t *uc_program_from_file(FILE *file, char **);
+
+uc_function_t *uc_program_entry(uc_program_t *);
+
 #endif /* __PROGRAM_H_ */

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Jo-Philipp Wich <jo@mein.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __PROGRAM_H_
+#define __PROGRAM_H_
+
+#include "types.h"
+
+
+uc_program_t *uc_program_new(void);
+
+void uc_program_free(uc_program_t *);
+
+uc_value_t *uc_program_function_new(uc_program_t *, const char *, size_t, uc_source_t *);
+size_t uc_program_function_id(uc_program_t *, uc_value_t *);
+uc_value_t *uc_program_function_load(uc_program_t *, size_t);
+
+#endif /* __PROGRAM_H_ */

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -28,4 +28,7 @@ uc_value_t *uc_program_function_new(uc_program_t *, const char *, size_t, uc_sou
 size_t uc_program_function_id(uc_program_t *, uc_value_t *);
 uc_value_t *uc_program_function_load(uc_program_t *, size_t);
 
+uc_value_t *uc_program_get_constant(uc_program_t *, size_t);
+ssize_t uc_program_add_constant(uc_program_t *, uc_value_t *);
+
 #endif /* __PROGRAM_H_ */

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -20,11 +20,11 @@
 #include "types.h"
 
 
-uc_program_t *uc_program_new(void);
+uc_program_t *uc_program_new(uc_source_t *);
 
 void uc_program_free(uc_program_t *);
 
-uc_value_t *uc_program_function_new(uc_program_t *, const char *, size_t, uc_source_t *);
+uc_value_t *uc_program_function_new(uc_program_t *, const char *, size_t);
 size_t uc_program_function_id(uc_program_t *, uc_value_t *);
 uc_value_t *uc_program_function_load(uc_program_t *, size_t);
 

--- a/include/ucode/source.h
+++ b/include/ucode/source.h
@@ -25,6 +25,10 @@
 #include "types.h"
 
 
+typedef enum {
+	UC_SOURCE_TYPE_PLAIN = 0,
+} uc_source_type_t;
+
 uc_source_t *uc_source_new_file(const char *path);
 uc_source_t *uc_source_new_buffer(const char *name, char *buf, size_t len);
 
@@ -32,5 +36,10 @@ size_t uc_source_get_line(uc_source_t *source, size_t *offset);
 
 uc_source_t *uc_source_get(uc_source_t *source);
 void uc_source_put(uc_source_t *source);
+
+uc_source_type_t uc_source_type_test(uc_source_t *source);
+
+void uc_source_line_next(uc_source_t *source);
+void uc_source_line_update(uc_source_t *source, size_t off);
 
 #endif /* __SOURCE_H_ */

--- a/include/ucode/source.h
+++ b/include/ucode/source.h
@@ -25,8 +25,11 @@
 #include "types.h"
 
 
+#define UC_PRECOMPILED_BYTECODE_MAGIC 0x1b756362  /* <esc> 'u' 'c' 'b' */
+
 typedef enum {
 	UC_SOURCE_TYPE_PLAIN = 0,
+	UC_SOURCE_TYPE_PRECOMPILED = 1,
 } uc_source_type_t;
 
 uc_source_t *uc_source_new_file(const char *path);

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -148,14 +148,16 @@ typedef struct {
 	char source[];
 } uc_regexp_t;
 
-typedef struct {
+typedef struct uc_function {
 	uc_value_t header;
-	bool arrow, vararg, strict;
+	bool arrow, vararg, strict, root;
 	size_t nargs;
 	size_t nupvals;
 	size_t srcpos;
 	uc_chunk_t chunk;
 	uc_source_t *source;
+	struct uc_program *program;
+	uc_weakref_t progref;
 	char name[];
 } uc_function_t;
 
@@ -197,6 +199,13 @@ typedef struct {
 } uc_resource_t;
 
 uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
+
+
+/* Program structure definitions */
+
+typedef struct uc_program {
+	uc_weakref_t functions;
+} uc_program_t;
 
 
 /* Parser definitions */
@@ -275,6 +284,9 @@ struct uc_vm {
 void ucv_free(uc_value_t *, bool);
 void ucv_put(uc_value_t *);
 
+void ucv_unref(uc_weakref_t *);
+void ucv_ref(uc_weakref_t *, uc_weakref_t *);
+
 uc_value_t *ucv_get(uc_value_t *uv);
 
 uc_type_t ucv_type(uc_value_t *);
@@ -338,7 +350,7 @@ size_t ucv_object_length(uc_value_t *);
 	                 : 0);																		\
 	     entry##key = entry_next##key)
 
-uc_value_t *ucv_function_new(const char *, size_t, uc_source_t *);
+uc_value_t *ucv_function_new(const char *, size_t, uc_source_t *, uc_program_t *);
 size_t ucv_function_srcpos(uc_value_t *, size_t);
 
 uc_value_t *ucv_cfunction_new(const char *, uc_cfn_ptr_t);

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -90,7 +90,6 @@ uc_declare_vector(uc_offsetinfo_t, uint8_t);
 typedef struct {
 	size_t count;
 	uint8_t *entries;
-	uc_value_list_t constants;
 	uc_ehranges_t ehranges;
 	struct {
 		uc_variables_t variables;
@@ -204,6 +203,7 @@ uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
 /* Program structure definitions */
 
 typedef struct uc_program {
+	uc_value_list_t constants;
 	uc_weakref_t functions;
 } uc_program_t;
 

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -154,7 +154,6 @@ typedef struct uc_function {
 	size_t nupvals;
 	size_t srcpos;
 	uc_chunk_t chunk;
-	uc_source_t *source;
 	struct uc_program *program;
 	uc_weakref_t progref;
 	char name[];
@@ -205,6 +204,7 @@ uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
 typedef struct uc_program {
 	uc_value_list_t constants;
 	uc_weakref_t functions;
+	uc_source_t *source;
 } uc_program_t;
 
 
@@ -350,7 +350,7 @@ size_t ucv_object_length(uc_value_t *);
 	                 : 0);																		\
 	     entry##key = entry_next##key)
 
-uc_value_t *ucv_function_new(const char *, size_t, uc_source_t *, uc_program_t *);
+uc_value_t *ucv_function_new(const char *, size_t, uc_program_t *);
 size_t ucv_function_srcpos(uc_value_t *, size_t);
 
 uc_value_t *ucv_cfunction_new(const char *, uc_cfn_ptr_t);

--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -71,8 +71,8 @@
 
 /* "failsafe" utility functions */
 
-static inline void *xalloc(size_t size) {
-	void *ptr = calloc(1, size);
+static inline void *xcalloc(size_t size, size_t nmemb) {
+	void *ptr = calloc(size, nmemb);
 
 	if (!ptr) {
 		fprintf(stderr, "Out of memory\n");
@@ -80,6 +80,10 @@ static inline void *xalloc(size_t size) {
 	}
 
 	return ptr;
+}
+
+static inline void *xalloc(size_t size) {
+	return xcalloc(1, size);
 }
 
 static inline void *xrealloc(void *ptr, size_t size) {

--- a/include/ucode/vallist.h
+++ b/include/ucode/vallist.h
@@ -38,7 +38,7 @@ typedef enum {
 	TAG_DBL = 3,
 	TAG_STR = 4,
 	TAG_LSTR = 5,
-	TAG_PTR = 6
+	TAG_FUNC = 6
 } uc_value_type_t;
 
 uc_value_t *uc_number_parse(const char *buf, char **end);

--- a/lexer.c
+++ b/lexer.c
@@ -54,6 +54,8 @@ struct token {
 	(((x) >= 'a') ? (10 + (x) - 'a') : \
 		(((x) >= 'A') ? (10 + (x) - 'A') : dec(x)))
 
+#ifndef NO_COMPILE
+
 static uc_token_t *parse_comment(uc_lexer_t *);
 static uc_token_t *parse_string(uc_lexer_t *);
 static uc_token_t *parse_regexp(uc_lexer_t *);
@@ -164,60 +166,6 @@ static const struct keyword reserved_words[] = {
 	{ TK_IN,		"in",    2 },
 };
 
-
-/*
- * Stores the given codepoint as a utf8 multibyte sequence into the given
- * output buffer and substracts the required amount of bytes from  the given
- * length pointer.
- *
- * Returns false if the multibyte sequence would not fit into the buffer,
- * otherwise true.
- */
-
-bool
-utf8enc(char **out, int *rem, int code)
-{
-	if (code >= 0 && code <= 0x7F) {
-		if (*rem < 1)
-			return false;
-
-		*(*out)++ = code; (*rem)--;
-
-		return true;
-	}
-	else if (code > 0 && code <= 0x7FF) {
-		if (*rem < 2)
-			return false;
-
-		*(*out)++ = ((code >>  6) & 0x1F) | 0xC0; (*rem)--;
-		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
-
-		return true;
-	}
-	else if (code > 0 && code <= 0xFFFF) {
-		if (*rem < 3)
-			return false;
-
-		*(*out)++ = ((code >> 12) & 0x0F) | 0xE0; (*rem)--;
-		*(*out)++ = ((code >>  6) & 0x3F) | 0x80; (*rem)--;
-		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
-
-		return true;
-	}
-	else if (code > 0 && code <= 0x10FFFF) {
-		if (*rem < 4)
-			return false;
-
-		*(*out)++ = ((code >> 18) & 0x07) | 0xF0; (*rem)--;
-		*(*out)++ = ((code >> 12) & 0x3F) | 0x80; (*rem)--;
-		*(*out)++ = ((code >>  6) & 0x3F) | 0x80; (*rem)--;
-		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
-
-		return true;
-	}
-
-	return true;
-}
 
 /* length of the longest token in our lookup table */
 #define UC_LEX_MAX_TOKEN_LEN 3
@@ -1186,4 +1134,60 @@ uc_lexer_is_keyword(uc_value_t *label)
 			return true;
 
 	return false;
+}
+
+#endif /* NO_COMPILE */
+
+/*
+ * Stores the given codepoint as a utf8 multibyte sequence into the given
+ * output buffer and substracts the required amount of bytes from  the given
+ * length pointer.
+ *
+ * Returns false if the multibyte sequence would not fit into the buffer,
+ * otherwise true.
+ */
+
+bool
+utf8enc(char **out, int *rem, int code)
+{
+	if (code >= 0 && code <= 0x7F) {
+		if (*rem < 1)
+			return false;
+
+		*(*out)++ = code; (*rem)--;
+
+		return true;
+	}
+	else if (code > 0 && code <= 0x7FF) {
+		if (*rem < 2)
+			return false;
+
+		*(*out)++ = ((code >>  6) & 0x1F) | 0xC0; (*rem)--;
+		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
+
+		return true;
+	}
+	else if (code > 0 && code <= 0xFFFF) {
+		if (*rem < 3)
+			return false;
+
+		*(*out)++ = ((code >> 12) & 0x0F) | 0xE0; (*rem)--;
+		*(*out)++ = ((code >>  6) & 0x3F) | 0x80; (*rem)--;
+		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
+
+		return true;
+	}
+	else if (code > 0 && code <= 0x10FFFF) {
+		if (*rem < 4)
+			return false;
+
+		*(*out)++ = ((code >> 18) & 0x07) | 0xF0; (*rem)--;
+		*(*out)++ = ((code >> 12) & 0x3F) | 0x80; (*rem)--;
+		*(*out)++ = ((code >>  6) & 0x3F) | 0x80; (*rem)--;
+		*(*out)++ = ( code        & 0x3F) | 0x80; (*rem)--;
+
+		return true;
+	}
+
+	return true;
 }

--- a/lib.c
+++ b/lib.c
@@ -2093,7 +2093,7 @@ uc_include(uc_vm_t *vm, size_t nargs)
 	if (!closure)
 		return NULL;
 
-	p = include_path(closure->function->source->filename, ucv_string_get(path));
+	p = include_path(closure->function->program->source->filename, ucv_string_get(path));
 
 	if (!p) {
 		uc_vm_raise_exception(vm, EXCEPTION_RUNTIME,
@@ -2505,7 +2505,7 @@ uc_sourcepath(uc_vm_t *vm, size_t nargs)
 			continue;
 		}
 
-		path = realpath(frame->closure->function->source->filename, NULL);
+		path = realpath(frame->closure->function->program->source->filename, NULL);
 		break;
 	}
 

--- a/program.c
+++ b/program.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Jo-Philipp Wich <jo@mein.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "ucode/program.h"
+
+
+uc_program_t *
+uc_program_new(void)
+{
+	uc_program_t *prog;
+
+	prog = xalloc(sizeof(*prog));
+
+	prog->functions.next = &prog->functions;
+	prog->functions.prev = &prog->functions;
+
+	return prog;
+}
+
+static inline uc_function_t *
+ref_to_function(uc_weakref_t *ref)
+{
+	return (uc_function_t *)((uintptr_t)ref - offsetof(uc_function_t, progref));
+}
+
+static inline uc_value_t *
+ref_to_uv(uc_weakref_t *ref)
+{
+	return (uc_value_t *)((uintptr_t)ref - offsetof(uc_function_t, progref));
+}
+
+void
+uc_program_free(uc_program_t *prog)
+{
+	uc_weakref_t *ref, *tmp;
+	uc_function_t *func;
+
+	if (!prog)
+		return;
+
+	for (ref = prog->functions.next, tmp = ref->next; ref != &prog->functions; ref = tmp, tmp = tmp->next) {
+		func = ref_to_function(ref);
+		func->program = NULL;
+		func->progref.next = NULL;
+		func->progref.prev = NULL;
+
+		ucv_put(&func->header);
+	}
+
+	free(prog);
+}
+
+uc_value_t *
+uc_program_function_new(uc_program_t *prog, const char *name, size_t srcpos, uc_source_t *source)
+{
+	uc_function_t *func;
+
+	func = (uc_function_t *)ucv_function_new(name, srcpos, source, prog);
+	func->root = (prog->functions.next == &prog->functions);
+
+	ucv_ref(&prog->functions, &func->progref);
+
+	return &func->header;
+}
+
+size_t
+uc_program_function_id(uc_program_t *prog, uc_value_t *func)
+{
+	uc_weakref_t *ref;
+	size_t i;
+
+	for (ref = prog->functions.prev, i = 1; ref != &prog->functions; ref = ref->prev, i++)
+		if (ref_to_uv(ref) == func)
+			return i;
+
+	return 0;
+}
+
+uc_value_t *
+uc_program_function_load(uc_program_t *prog, size_t id)
+{
+	uc_weakref_t *ref;
+	size_t i;
+
+	for (ref = prog->functions.prev, i = 1; ref != &prog->functions; ref = ref->prev, i++)
+		if (i == id)
+			return ref_to_uv(ref);
+
+	return NULL;
+}

--- a/program.c
+++ b/program.c
@@ -14,6 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <assert.h>
+#include <errno.h>
+#include <endian.h>
+
 #include "ucode/program.h"
 #include "ucode/source.h"
 #include "ucode/vallist.h"
@@ -120,4 +124,668 @@ ssize_t
 uc_program_add_constant(uc_program_t *prog, uc_value_t *val)
 {
 	return uc_vallist_add(&prog->constants, val);
+}
+
+static void
+write_u16(size_t value, FILE *file)
+{
+	uint16_t n;
+
+	if (sizeof(value) > sizeof(n))
+		assert(value <= UINT16_MAX);
+
+	n = htobe16((uint16_t)value);
+
+	fwrite(&n, 1, sizeof(n), file);
+}
+
+static void
+write_u32(size_t value, FILE *file)
+{
+	uint32_t n;
+
+	if (sizeof(value) > sizeof(n))
+		assert(value <= UINT32_MAX);
+
+	n = htobe32((uint32_t)value);
+
+	fwrite(&n, 1, sizeof(n), file);
+}
+
+static void
+write_u64(uint64_t value, FILE *file)
+{
+	uint64_t n;
+
+	if (sizeof(value) > sizeof(n))
+		assert(value <= UINT64_MAX);
+
+	n = htobe64((uint64_t)value);
+
+	fwrite(&n, 1, sizeof(n), file);
+}
+
+static void
+_write_vector(size_t count, size_t itemsize, void *data, FILE *file)
+{
+	size_t pad = (~(count * itemsize) + 1) & (sizeof(uint32_t) - 1);
+	char z[sizeof(uint32_t) - 1] = { 0 };
+
+	write_u32(count, file);
+	fwrite(data, itemsize, count, file);
+	fwrite(z, 1, pad, file);
+}
+
+#define write_vector(vec, file) \
+	_write_vector((vec)->count, sizeof((vec)->entries[0]), (vec)->entries, file)
+
+#define write_string(str, file) \
+	_write_vector(strlen(str) + 1, 1, str, file)
+
+static void
+write_vallist(uc_value_list_t *vallist, FILE *file)
+{
+	size_t i;
+
+	/* write index */
+	write_u32(vallist->isize, file);
+
+	for (i = 0; i < vallist->isize; i++)
+		write_u64(vallist->index[i], file);
+
+	/* write data */
+	write_u32(vallist->dsize, file);
+	fwrite(vallist->data, 1, vallist->dsize, file);
+}
+
+enum {
+	UC_PROGRAM_F_DEBUG      = (1 << 0),
+	UC_PROGRAM_F_SOURCEINFO = (1 << 1),
+	UC_PROGRAM_F_SOURCEBUF  = (1 << 2),
+};
+
+enum {
+	UC_FUNCTION_F_IS_ARROW       = (1 << 0),
+	UC_FUNCTION_F_IS_VARARG      = (1 << 1),
+	UC_FUNCTION_F_IS_STRICT      = (1 << 2),
+	UC_FUNCTION_F_HAS_EXCEPTIONS = (1 << 3),
+	UC_FUNCTION_F_HAS_NAME       = (1 << 4),
+	UC_FUNCTION_F_HAS_VARDBG     = (1 << 5),
+	UC_FUNCTION_F_HAS_OFFSETDBG  = (1 << 6),
+};
+
+static void
+write_chunk(uc_chunk_t *chunk, FILE *file, uint32_t flags)
+{
+	size_t i;
+
+	/* write bytecode data */
+	write_vector(chunk, file);
+
+	/* write exception ranges */
+	if (flags & UC_FUNCTION_F_HAS_EXCEPTIONS) {
+		write_u32(chunk->ehranges.count, file);
+
+		for (i = 0; i < chunk->ehranges.count; i++) {
+			write_u32(chunk->ehranges.entries[i].from,   file);
+			write_u32(chunk->ehranges.entries[i].to,     file);
+			write_u32(chunk->ehranges.entries[i].target, file);
+			write_u32(chunk->ehranges.entries[i].slot,   file);
+		}
+	}
+
+	/* write variable info */
+	if (flags & UC_FUNCTION_F_HAS_VARDBG) {
+		write_u32(chunk->debuginfo.variables.count, file);
+
+		for (i = 0; i < chunk->debuginfo.variables.count; i++) {
+			write_u32(chunk->debuginfo.variables.entries[i].from,    file);
+			write_u32(chunk->debuginfo.variables.entries[i].to,      file);
+			write_u32(chunk->debuginfo.variables.entries[i].slot,    file);
+			write_u32(chunk->debuginfo.variables.entries[i].nameidx, file);
+		}
+
+		write_vallist(&chunk->debuginfo.varnames, file);
+	}
+
+	/* write offset info */
+	if (flags & UC_FUNCTION_F_HAS_OFFSETDBG)
+		write_vector(&chunk->debuginfo.offsets, file);
+}
+
+static void
+write_function(uc_function_t *func, FILE *file, bool debug)
+{
+	uint32_t flags = 0;
+
+	if (func->arrow)
+		flags |= UC_FUNCTION_F_IS_ARROW;
+
+	if (func->vararg)
+		flags |= UC_FUNCTION_F_IS_VARARG;
+
+	if (func->strict)
+		flags |= UC_FUNCTION_F_IS_STRICT;
+
+	if (func->chunk.ehranges.count)
+		flags |= UC_FUNCTION_F_HAS_EXCEPTIONS;
+
+	if (debug && func->name[0])
+		flags |= UC_FUNCTION_F_HAS_NAME;
+
+	if (debug && func->chunk.debuginfo.variables.count)
+		flags |= UC_FUNCTION_F_HAS_VARDBG;
+
+	if (debug && func->chunk.debuginfo.offsets.count)
+		flags |= UC_FUNCTION_F_HAS_OFFSETDBG;
+
+	write_u32(flags, file);
+
+	if (flags & UC_FUNCTION_F_HAS_NAME)
+		write_string(func->name, file);
+
+	write_u16(func->nargs, file);
+	write_u16(func->nupvals, file);
+	write_u32(func->srcpos, file);
+
+	write_chunk(&func->chunk, file, flags);
+}
+
+void
+uc_program_to_file(uc_program_t *prog, FILE *file, bool debug)
+{
+	uint32_t flags = 0;
+	uc_weakref_t *ref;
+	size_t i;
+
+	if (debug)
+		flags |= UC_PROGRAM_F_DEBUG;
+
+	if (debug && prog->source) {
+		flags |= UC_PROGRAM_F_SOURCEINFO;
+
+		if (prog->source->buffer)
+			flags |= UC_PROGRAM_F_SOURCEBUF;
+	}
+
+	/* magic word + flags */
+	write_u32(UC_PRECOMPILED_BYTECODE_MAGIC, file);
+	write_u32(flags, file);
+
+	if (flags & UC_PROGRAM_F_SOURCEINFO) {
+		/* write source file name */
+		write_string(prog->source->filename, file);
+
+		/* include source buffer if program was compiled from stdin */
+		if (flags & UC_PROGRAM_F_SOURCEBUF)
+			write_string(prog->source->buffer, file);
+
+		/* write lineinfo data */
+		write_vector(&prog->source->lineinfo, file);
+	}
+
+	/* write constants */
+	write_vallist(&prog->constants, file);
+
+	/* write program sections */
+	for (i = 0, ref = prog->functions.prev; ref != &prog->functions; ref = ref->prev)
+		i++;
+
+	write_u32(i, file);
+
+	for (ref = prog->functions.prev; ref != &prog->functions; ref = ref->prev)
+		write_function(ref_to_function(ref), file, debug);
+}
+
+static bool
+read_error(FILE *file, char **errp, const char *subject, size_t rlen, size_t len)
+{
+	const char *reason;
+
+	if (feof(file))
+		reason = "Premature EOF";
+	else
+		reason = strerror(errno);
+
+	if (errp)
+		xasprintf(errp,
+		          "%s while reading %s at offset %ld, got %zu of %zu bytes\n",
+		          reason, subject, ftell(file) - rlen, rlen, len);
+
+	return false;
+}
+
+static bool
+skip_padding(FILE *file, size_t len, char **errp)
+{
+	size_t pad = (~len + 1) & (sizeof(uint32_t) - 1), rlen;
+	char buf[sizeof(uint32_t) - 1];
+
+	if (pad != 0) {
+		rlen = fread(buf, 1, pad, file);
+
+		if (rlen != pad)
+			return read_error(file, errp, "padding", rlen, pad);
+	}
+
+	return true;
+}
+
+static bool
+read_u32(FILE *file, uint32_t *n, const char *subj, char **errp)
+{
+	size_t rlen = fread(n, 1, sizeof(*n), file);
+
+	if (rlen != sizeof(*n)) {
+		*n = 0;
+
+		return read_error(file, errp, subj ? subj : "uint32_t", rlen, sizeof(*n));
+	}
+
+	*n = be32toh(*n);
+
+	return true;
+}
+
+static bool
+read_u64(FILE *file, uint64_t *n, const char *subj, char **errp)
+{
+	size_t rlen = fread(n, 1, sizeof(*n), file);
+
+	if (rlen != sizeof(*n)) {
+		*n = 0;
+
+		return read_error(file, errp, subj ? subj : "uint64_t", rlen, sizeof(*n));
+	}
+
+	*n = be64toh(*n);
+
+	return true;
+}
+
+static bool
+read_size_t(FILE *file, size_t *n, size_t size, const char *subj, char **errp)
+{
+	union { uint8_t u8; uint16_t u16; uint32_t u32; uint64_t u64; } nval;
+	size_t rlen;
+
+	rlen = fread(&nval.u64, 1, size, file);
+
+	if (rlen != size) {
+		*n = 0;
+
+		if (!subj) {
+			switch (size) {
+			case 1: subj = "uint8_t";  break;
+			case 2: subj = "uint16_t"; break;
+			case 4: subj = "uint32_t"; break;
+			case 8: subj = "uint64_t"; break;
+			}
+		}
+
+		return read_error(file, errp, subj, rlen, sizeof(nval));
+	}
+
+	switch (size) {
+	case 1: *n = (size_t)        nval.u8;   break;
+	case 2: *n = (size_t)be16toh(nval.u16); break;
+	case 4: *n = (size_t)be32toh(nval.u32); break;
+	case 8: *n = (size_t)be64toh(nval.u64); break;
+	}
+
+	return true;
+}
+
+static bool
+_read_vector(FILE *file, void *ptr, size_t itemsize, const char *subj, char **errp)
+{
+	struct { size_t count; void *data; } *vec = ptr;
+	size_t rlen, len;
+	char subjbuf[64];
+
+	snprintf(subjbuf, sizeof(subjbuf), "%s vector size", subj);
+
+	if (!read_size_t(file, &vec->count, sizeof(uint32_t), subjbuf, errp))
+		return false;
+
+	vec->data = xcalloc(vec->count, itemsize);
+
+	len = vec->count;
+	rlen = fread(vec->data, itemsize, len, file);
+
+	if (rlen != len) {
+		free(vec->data);
+
+		vec->count = 0;
+		vec->data = NULL;
+
+		snprintf(subjbuf, sizeof(subjbuf), "%s vector data", subj);
+
+		return read_error(file, errp, subjbuf, rlen * itemsize, len * itemsize);
+	}
+
+	return skip_padding(file, vec->count * itemsize, errp);
+}
+
+#define read_vector(file, vec, subj, errp) \
+	_read_vector(file, vec, sizeof((vec)->entries[0]), subj, errp)
+
+static bool
+read_string(FILE *file, char *dst, size_t len, const char *subj, char **errp)
+{
+	size_t rlen;
+
+	rlen = fread(dst, 1, len, file);
+
+	if (rlen != len)
+		return read_error(file, errp, subj, rlen, len);
+
+	return skip_padding(file, len, errp);
+}
+
+static bool
+read_vallist(FILE *file, uc_value_list_t *vallist, const char *subj, char **errp)
+{
+	char subjbuf[64];
+	size_t i;
+
+	/* read index */
+	snprintf(subjbuf, sizeof(subjbuf), "%s index size", subj);
+
+	if (!read_size_t(file, &vallist->isize, sizeof(uint32_t), subjbuf, errp))
+		goto out;
+
+	vallist->index = xcalloc(sizeof(vallist->index[0]), vallist->isize);
+
+	for (i = 0; i < vallist->isize; i++) {
+		snprintf(subjbuf, sizeof(subjbuf), "%s index entry %zu of %zu", subj, i, vallist->isize);
+
+		if (!read_u64(file, &vallist->index[i], subjbuf, errp))
+			goto out;
+	}
+
+	/* read data */
+	snprintf(subjbuf, sizeof(subjbuf), "%s data size", subj);
+
+	if (!read_size_t(file, &vallist->dsize, sizeof(uint32_t), subjbuf, errp))
+		goto out;
+
+	vallist->data = xalloc(vallist->dsize);
+
+	snprintf(subjbuf, sizeof(subjbuf), "%s data", subj);
+
+	if (!read_string(file, vallist->data, vallist->dsize, subj, errp))
+		goto out;
+
+	return true;
+
+out:
+	free(vallist->index);
+	free(vallist->data);
+
+	vallist->isize = 0;
+	vallist->index = NULL;
+
+	vallist->dsize = 0;
+	vallist->data = NULL;
+
+	return false;
+}
+
+static uc_source_t *
+read_sourceinfo(FILE *file, uint32_t flags, char **errp)
+{
+	char *path = NULL, *code = NULL;
+	uc_source_t *source = NULL;
+	size_t len;
+
+	if (flags & UC_PROGRAM_F_SOURCEINFO) {
+		if (!read_size_t(file, &len, sizeof(uint32_t), "sourceinfo filename length", errp))
+			goto out;
+
+		path = xalloc(len);
+
+		if (!read_string(file, path, len, "sourceinfo filename", errp))
+			goto out;
+
+		if (flags & UC_PROGRAM_F_SOURCEBUF) {
+			if (!read_size_t(file, &len, sizeof(uint32_t), "sourceinfo code buffer length", errp))
+				goto out;
+
+			code = xalloc(len);
+
+			if (!read_string(file, code, len, "sourceinfo code buffer data", errp))
+				goto out;
+
+			source = uc_source_new_buffer(path, code, len);
+		}
+		else {
+			source = uc_source_new_file(path);
+
+			if (!source) {
+				fprintf(stderr, "Unable to open source file %s: %s\n", path, strerror(errno));
+				source = uc_source_new_buffer(path, "", 0);
+			}
+		}
+
+		if (!read_vector(file, &source->lineinfo, "sourceinfo lineinfo", errp)) {
+			uc_source_put(source);
+			source = NULL;
+			goto out;
+		}
+	}
+	else {
+		source = uc_source_new_buffer("[no source]", xstrdup(""), 0);
+	}
+
+out:
+	free(path);
+	free(code);
+
+	return source;
+}
+
+static bool
+read_chunk(FILE *file, uc_chunk_t *chunk, uint32_t flags, const char *subj, char **errp)
+{
+	uc_varrange_t *varrange;
+	uc_ehrange_t *ehrange;
+	char subjbuf[192];
+	size_t i;
+
+	/* read bytecode data */
+	snprintf(subjbuf, sizeof(subjbuf), "%s byte code", subj);
+
+	if (!read_vector(file, chunk, subjbuf, errp))
+		goto out;
+
+	/* read exception ranges */
+	if (flags & UC_FUNCTION_F_HAS_EXCEPTIONS) {
+		snprintf(subjbuf, sizeof(subjbuf), "%s exception ranges count", subj);
+
+		if (!read_size_t(file, &chunk->ehranges.count, sizeof(uint32_t), subjbuf, errp))
+			goto out;
+
+		chunk->ehranges.entries = xcalloc(
+			sizeof(chunk->ehranges.entries[0]),
+			chunk->ehranges.count);
+
+		for (i = 0; i < chunk->ehranges.count; i++) {
+			snprintf(subjbuf, sizeof(subjbuf), "%s exception range %zu of %zu offset",
+				subj, i, chunk->ehranges.count);
+
+			ehrange = &chunk->ehranges.entries[i];
+
+			if (!read_size_t(file, &ehrange->from,   sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &ehrange->to,     sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &ehrange->target, sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &ehrange->slot,   sizeof(uint32_t), subjbuf, errp))
+				goto out;
+		}
+	}
+
+	/* read variable info */
+	if (flags & UC_FUNCTION_F_HAS_VARDBG) {
+		snprintf(subjbuf, sizeof(subjbuf), "%s variable scopes count", subj);
+
+		if (!read_size_t(file, &chunk->debuginfo.variables.count, sizeof(uint32_t), subjbuf, errp))
+			goto out;
+
+		chunk->debuginfo.variables.entries = xcalloc(
+			sizeof(chunk->debuginfo.variables.entries[0]),
+			chunk->debuginfo.variables.count);
+
+		for (i = 0; i < chunk->debuginfo.variables.count; i++) {
+			snprintf(subjbuf, sizeof(subjbuf), "%s variable scope %zu of %zu offset",
+				subj, i, chunk->debuginfo.variables.count);
+
+			varrange = &chunk->debuginfo.variables.entries[i];
+
+			if (!read_size_t(file, &varrange->from,    sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &varrange->to,      sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &varrange->slot,    sizeof(uint32_t), subjbuf, errp) ||
+			    !read_size_t(file, &varrange->nameidx, sizeof(uint32_t), subjbuf, errp))
+			    goto out;
+		}
+
+		snprintf(subjbuf, sizeof(subjbuf), "%s variable names", subj);
+
+		if (!read_vallist(file, &chunk->debuginfo.varnames, subjbuf, errp))
+			goto out;
+	}
+
+	/* read offset info */
+	if (flags & UC_FUNCTION_F_HAS_OFFSETDBG) {
+		snprintf(subjbuf, sizeof(subjbuf), "%s source offsets", subj);
+
+		if (!read_vector(file, &chunk->debuginfo.offsets, subjbuf, errp))
+			goto out;
+	}
+
+	return true;
+
+out:
+	uc_vallist_free(&chunk->debuginfo.varnames);
+
+	free(chunk->entries);
+	free(chunk->ehranges.entries);
+	free(chunk->debuginfo.variables.entries);
+
+	chunk->count = 0;
+	chunk->entries = NULL;
+
+	chunk->ehranges.count = 0;
+	chunk->ehranges.entries = NULL;
+
+	chunk->debuginfo.variables.count = 0;
+	chunk->debuginfo.variables.entries = NULL;
+
+	return false;
+}
+
+static bool
+read_function(FILE *file, uc_program_t *program, size_t idx, char **errp)
+{
+	char subjbuf[64], *name = NULL;
+	uc_function_t *func = NULL;
+	uint32_t flags, u32;
+
+	snprintf(subjbuf, sizeof(subjbuf), "function #%zu flags", idx);
+
+	if (!read_u32(file, &flags, subjbuf, errp))
+		goto out;
+
+	if (flags & UC_FUNCTION_F_HAS_NAME) {
+		snprintf(subjbuf, sizeof(subjbuf), "function #%zu name length", idx);
+
+		if (!read_u32(file, &u32, subjbuf, errp))
+			goto out;
+
+		name = xalloc(u32);
+
+		snprintf(subjbuf, sizeof(subjbuf), "function #%zu name", idx);
+
+		if (!read_string(file, name, u32, subjbuf, errp))
+			goto out;
+	}
+
+	snprintf(subjbuf, sizeof(subjbuf), "function #%zu (%s) arg count and offset", idx, name ? name : "-");
+
+	func = (uc_function_t *)uc_program_function_new(program, name, 0);
+	func->arrow   = (flags & UC_FUNCTION_F_IS_ARROW);
+	func->vararg  = (flags & UC_FUNCTION_F_IS_VARARG);
+	func->strict  = (flags & UC_FUNCTION_F_IS_STRICT);
+
+	if (!read_size_t(file, &func->nargs,   sizeof(uint16_t), subjbuf, errp) ||
+	    !read_size_t(file, &func->nupvals, sizeof(uint16_t), subjbuf, errp) ||
+	    !read_size_t(file, &func->srcpos,  sizeof(uint32_t), subjbuf, errp))
+		goto out;
+
+	snprintf(subjbuf, sizeof(subjbuf), "function #%zu (%s) body", idx, name ? name : "-");
+
+	if (!read_chunk(file, &func->chunk, flags, subjbuf, errp))
+		goto out;
+
+	free(name);
+
+	return true;
+
+out:
+	free(name);
+
+	return false;
+}
+
+uc_program_t *
+uc_program_from_file(FILE *file, char **errp)
+{
+	uc_program_t *program = NULL;
+	uc_source_t *source = NULL;
+	uint32_t flags, nfuncs, i;
+
+	if (!read_u32(file, &i, "file magic", errp))
+		goto out;
+
+	if (i != UC_PRECOMPILED_BYTECODE_MAGIC) {
+		xasprintf(errp, "Invalid file magic\n");
+		goto out;
+	}
+
+	if (!read_u32(file, &flags, "program flags", errp))
+		goto out;
+
+	source = read_sourceinfo(file, flags, errp);
+
+	if (!source)
+		goto out;
+
+	program = uc_program_new(source);
+
+	uc_source_put(source);
+
+	if (!read_vallist(file, &program->constants, "constants", errp))
+		goto out;
+
+	if (!read_u32(file, &nfuncs, "function count", errp))
+		goto out;
+
+	for (i = 0; i < nfuncs; i++)
+		if (!read_function(file, program, i, errp))
+			goto out;
+
+	return program;
+
+out:
+	uc_program_free(program);
+
+	return NULL;
+}
+
+uc_function_t *
+uc_program_entry(uc_program_t *program)
+{
+	if (program->functions.prev == &program->functions)
+		return NULL;
+
+	return ref_to_function(program->functions.prev);
 }

--- a/program.c
+++ b/program.c
@@ -15,6 +15,7 @@
  */
 
 #include "ucode/program.h"
+#include "ucode/vallist.h"
 
 
 uc_program_t *
@@ -26,6 +27,8 @@ uc_program_new(void)
 
 	prog->functions.next = &prog->functions;
 	prog->functions.prev = &prog->functions;
+
+	uc_vallist_init(&prog->constants);
 
 	return prog;
 }
@@ -60,6 +63,7 @@ uc_program_free(uc_program_t *prog)
 		ucv_put(&func->header);
 	}
 
+	uc_vallist_free(&prog->constants);
 	free(prog);
 }
 
@@ -100,4 +104,16 @@ uc_program_function_load(uc_program_t *prog, size_t id)
 			return ref_to_uv(ref);
 
 	return NULL;
+}
+
+uc_value_t *
+uc_program_get_constant(uc_program_t *prog, size_t idx)
+{
+	return uc_vallist_get(&prog->constants, idx);
+}
+
+ssize_t
+uc_program_add_constant(uc_program_t *prog, uc_value_t *val)
+{
+	return uc_vallist_add(&prog->constants, val);
 }

--- a/program.c
+++ b/program.c
@@ -15,11 +15,12 @@
  */
 
 #include "ucode/program.h"
+#include "ucode/source.h"
 #include "ucode/vallist.h"
 
 
 uc_program_t *
-uc_program_new(void)
+uc_program_new(uc_source_t *source)
 {
 	uc_program_t *prog;
 
@@ -27,6 +28,8 @@ uc_program_new(void)
 
 	prog->functions.next = &prog->functions;
 	prog->functions.prev = &prog->functions;
+
+	prog->source = uc_source_get(source);
 
 	uc_vallist_init(&prog->constants);
 
@@ -64,15 +67,16 @@ uc_program_free(uc_program_t *prog)
 	}
 
 	uc_vallist_free(&prog->constants);
+	uc_source_put(prog->source);
 	free(prog);
 }
 
 uc_value_t *
-uc_program_function_new(uc_program_t *prog, const char *name, size_t srcpos, uc_source_t *source)
+uc_program_function_new(uc_program_t *prog, const char *name, size_t srcpos)
 {
 	uc_function_t *func;
 
-	func = (uc_function_t *)ucv_function_new(name, srcpos, source, prog);
+	func = (uc_function_t *)ucv_function_new(name, srcpos, prog);
 	func->root = (prog->functions.next == &prog->functions);
 
 	ucv_ref(&prog->functions, &func->progref);

--- a/tests/cram/test_basic.t
+++ b/tests/cram/test_basic.t
@@ -25,6 +25,8 @@ check that ucode provides exepected help:
     -E Set global variables from given JSON file
     -x Disable given function
     -m Preload given module
+    -o Write precompiled byte code to given file
+    -O Write precompiled byte code to given file and strip debug information
 
 check that ucode prints greetings:
 

--- a/types.c
+++ b/types.c
@@ -248,7 +248,6 @@ ucv_free(uc_value_t *uv, bool retain)
 		}
 
 		uc_chunk_free(&function->chunk);
-		uc_source_put(function->source);
 		break;
 
 	case UC_CLOSURE:
@@ -951,7 +950,7 @@ ucv_object_length(uc_value_t *uv)
 
 
 uc_value_t *
-ucv_function_new(const char *name, size_t srcpos, uc_source_t *source, uc_program_t *program)
+ucv_function_new(const char *name, size_t srcpos, uc_program_t *program)
 {
 	size_t namelen = 0;
 	uc_function_t *fn;
@@ -969,7 +968,6 @@ ucv_function_new(const char *name, size_t srcpos, uc_source_t *source, uc_progra
 	fn->nargs = 0;
 	fn->nupvals = 0;
 	fn->srcpos = srcpos;
-	fn->source = uc_source_get(source);
 	fn->program = program;
 	fn->vararg = false;
 

--- a/types.c
+++ b/types.c
@@ -26,6 +26,7 @@
 #include "ucode/types.h"
 #include "ucode/util.h"
 #include "ucode/vm.h"
+#include "ucode/program.h"
 
 uc_type_t
 ucv_type(uc_value_t *uv)
@@ -60,14 +61,14 @@ ucv_typename(uc_value_t *uv)
 	return "unknown";
 }
 
-static void
+void
 ucv_unref(uc_weakref_t *ref)
 {
 	ref->prev->next = ref->next;
 	ref->next->prev = ref->prev;
 }
 
-static void
+void
 ucv_ref(uc_weakref_t *head, uc_weakref_t *item)
 {
 	item->next = head->next;
@@ -238,6 +239,14 @@ ucv_free(uc_value_t *uv, bool retain)
 
 	case UC_FUNCTION:
 		function = (uc_function_t *)uv;
+
+		if (function->program) {
+			ucv_unref(&function->progref);
+
+			if (function->root)
+				uc_program_free(function->program);
+		}
+
 		uc_chunk_free(&function->chunk);
 		uc_source_put(function->source);
 		break;
@@ -942,7 +951,7 @@ ucv_object_length(uc_value_t *uv)
 
 
 uc_value_t *
-ucv_function_new(const char *name, size_t srcpos, uc_source_t *source)
+ucv_function_new(const char *name, size_t srcpos, uc_source_t *source, uc_program_t *program)
 {
 	size_t namelen = 0;
 	uc_function_t *fn;
@@ -961,6 +970,7 @@ ucv_function_new(const char *name, size_t srcpos, uc_source_t *source)
 	fn->nupvals = 0;
 	fn->srcpos = srcpos;
 	fn->source = uc_source_get(source);
+	fn->program = program;
 	fn->vararg = false;
 
 	uc_chunk_init(&fn->chunk);
@@ -1019,6 +1029,8 @@ ucv_closure_new(uc_vm_t *vm, uc_function_t *function, bool arrow_fn)
 
 	if (vm)
 		ucv_ref(&vm->values, &closure->ref);
+
+	ucv_get(&function->header);
 
 	return &closure->header;
 }

--- a/vallist.c
+++ b/vallist.c
@@ -553,8 +553,7 @@ uc_value_t *
 uc_vallist_get(uc_value_list_t *list, size_t idx)
 {
 	char str[sizeof(TAG_TYPE)];
-	uc_function_t *func;
-	uc_chunk_t *chunk;
+	uc_program_t *program;
 	size_t n, len;
 
 	switch (uc_vallist_type(list, idx)) {
@@ -593,10 +592,9 @@ uc_vallist_get(uc_value_list_t *list, size_t idx)
 		return ucv_string_new_length(list->data + TAG_GET_OFFSET(list->index[idx]) + sizeof(uint32_t), len);
 
 	case TAG_FUNC:
-		chunk = container_of(list, uc_chunk_t, constants);
-		func = container_of(chunk, uc_function_t, chunk);
+		program = container_of(list, uc_program_t, constants);
 
-		return uc_program_function_load(func->program, TAG_GET_NV(list->index[idx]));
+		return uc_program_function_load(program, TAG_GET_NV(list->index[idx]));
 
 	default:
 		return NULL;

--- a/vm.c
+++ b/vm.c
@@ -2602,6 +2602,8 @@ uc_vm_execute(uc_vm_t *vm, uc_function_t *fn, uc_value_t **retval)
 		break;
 	}
 
+	ucv_put(&fn->header);
+
 	return status;
 }
 


### PR DESCRIPTION
This PR adds a series of commits to support bytecode precompilation in ucode:

- **types: add initial infrastructure for function serialization**
  Introduces a new logical "program" object which holds the list of compiled functions,
  changes handling of function values in constant lists; instead of storing the pointer values
  directly, it stores an index into the program's function list
- **compiler, vm: use a program wide constant list**
  So far, each compiled ucode function maintained its own constant data list which leads
  to considerable overhead if a program consists of many functions. This commit moves
  the per-function constant data into one global per-program constant data area, avoiding
  duplication of large constant values
- **source: refactor source file handling**
  Introduces support to identify the kind of source file and reshuffles some logic to better
  align with the responsibility of the different components
- **program: implement support for precompiling source files**
  This commits extends ucode to be able to serialize the in-memory representation of a
  compiled program into a file and adds accompanying code to parse such precompiled
  files back into in-memory representation. The file format is platform agnostic
- **build: support building without compile capabilities**
  Introduces a new compile time option to disable code responsible for compiling plaintext
  ucode sources. An interpreter built with compilation support disabled will only be able
  to load and execute precompiled files.