### PR TITLE
Bytecode fixes

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -2881,7 +2881,7 @@ uc_compile_from_bytecode(uc_parse_config_t *config, uc_source_t *source, char **
 	uc_function_t *fn = NULL;
 	uc_program_t *prog;
 
-	prog = uc_program_from_file(source->fp, errp);
+	prog = uc_program_load(source, errp);
 
 	if (prog) {
 		fn = uc_program_entry(prog);

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -31,8 +31,8 @@ uc_value_t *uc_program_function_load(uc_program_t *, size_t);
 uc_value_t *uc_program_get_constant(uc_program_t *, size_t);
 ssize_t uc_program_add_constant(uc_program_t *, uc_value_t *);
 
-void uc_program_to_file(uc_program_t *, FILE *, bool);
-uc_program_t *uc_program_from_file(FILE *file, char **);
+void uc_program_write(uc_program_t *, FILE *, bool);
+uc_program_t *uc_program_load(uc_source_t *, char **);
 
 uc_function_t *uc_program_entry(uc_program_t *);
 

--- a/include/ucode/source.h
+++ b/include/ucode/source.h
@@ -45,4 +45,6 @@ uc_source_type_t uc_source_type_test(uc_source_t *source);
 void uc_source_line_next(uc_source_t *source);
 void uc_source_line_update(uc_source_t *source, size_t off);
 
+void uc_source_runpath_set(uc_source_t *source, const char *runpath);
+
 #endif /* __SOURCE_H_ */

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -66,7 +66,7 @@ typedef struct {
 uc_declare_vector(uc_lineinfo_t, uint8_t);
 
 typedef struct {
-	char *filename, *buffer;
+	char *filename, *runpath, *buffer;
 	FILE *fp;
 	size_t usecount, off;
 	uc_lineinfo_t lineinfo;

--- a/lib.c
+++ b/lib.c
@@ -2141,7 +2141,7 @@ uc_include(uc_vm_t *vm, size_t nargs)
 	if (!closure)
 		return NULL;
 
-	p = include_path(closure->function->program->source->filename, ucv_string_get(path));
+	p = include_path(closure->function->program->source->runpath, ucv_string_get(path));
 
 	if (!p) {
 		uc_vm_raise_exception(vm, EXCEPTION_RUNTIME,
@@ -2553,7 +2553,7 @@ uc_sourcepath(uc_vm_t *vm, size_t nargs)
 			continue;
 		}
 
-		path = realpath(frame->closure->function->program->source->filename, NULL);
+		path = realpath(frame->closure->function->program->source->runpath, NULL);
 		break;
 	}
 

--- a/lib.c
+++ b/lib.c
@@ -1558,6 +1558,7 @@ uc_require_ucode(uc_vm_t *vm, const char *path, uc_value_t *scope, uc_value_t **
 		*res = uc_vm_stack_pop(vm);
 
 	uc_source_put(source);
+	ucv_put(&function->header);
 
 	return true;
 }

--- a/main.c
+++ b/main.c
@@ -95,7 +95,7 @@ compile(uc_vm_t *vm, uc_source_t *src, FILE *precompile, bool strip)
 	}
 
 	if (precompile) {
-		uc_program_to_file(entry->program, precompile, !strip);
+		uc_program_write(entry->program, precompile, !strip);
 		uc_program_free(entry->program);
 		fclose(precompile);
 		goto out;

--- a/source.c
+++ b/source.c
@@ -34,6 +34,7 @@ uc_source_new_file(const char *path)
 	src->fp = fp;
 	src->buffer = NULL;
 	src->filename = strcpy((char *)src + ALIGN(sizeof(*src)), path);
+	src->runpath = src->filename;
 
 	src->usecount = 1;
 
@@ -112,6 +113,9 @@ uc_source_put(uc_source_t *source)
 
 		return;
 	}
+
+	if (source->runpath != source->filename)
+		free(source->runpath);
 
 	uc_vector_clear(&source->lineinfo);
 	fclose(source->fp);
@@ -210,4 +214,13 @@ uc_source_line_update(uc_source_t *source, size_t off)
 			lines->count++;
 		}
 	}
+}
+
+void
+uc_source_runpath_set(uc_source_t *source, const char *runpath)
+{
+	if (source->runpath != source->filename)
+		free(source->runpath);
+
+	source->runpath = xstrdup(runpath);
 }


### PR DESCRIPTION
Fix two issues encountered while testing precompilation on complex programs:

 - Within `uc_require_ucode()`, the compiled program function was not released after invoking it, leading to a leak of the function itself and all associated values
 - When executing precompiled bytecode files, the effective path of the file being executed by the VM was not tracked, instead the source buffer `->filename` member referred to the path of the original source file or - in case of stripped debug information - nowhere, causing `uc_include()` and `uc_sourcepath()` to fail

These changes address these issues and modify the bytecode loading API while we're touching it.