### PR TITLE
treewide: rework function memory model

### DIFF
--- a/examples/exception-handler.c
+++ b/examples/exception-handler.c
@@ -23,7 +23,7 @@
 
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
-static const char *program = MULTILINE_STRING(
+static const char *program_code = MULTILINE_STRING(
 	{%
 		function fail() {
 			/* invoke not existing function to raise runtime error */
@@ -58,17 +58,17 @@ int main(int argc, char **argv)
 	int exit_code = 0;
 
 	/* create a source buffer containing the program code */
-	uc_source_t *src = uc_source_new_buffer("my program", strdup(program), strlen(program));
+	uc_source_t *src = uc_source_new_buffer("my program", strdup(program_code), strlen(program_code));
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
 	uc_vm_exception_handler_set(&vm, log_exception);
 
 	/* execute program function */
-	int return_code = uc_vm_execute(&vm, progfunc, NULL);
+	int return_code = uc_vm_execute(&vm, program, NULL);
 
 	/* handle return status */
 	if (return_code == ERROR_COMPILE || return_code == ERROR_RUNTIME) {

--- a/examples/execute-file.c
+++ b/examples/execute-file.c
@@ -49,13 +49,13 @@ int main(int argc, char **argv)
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
 	/* execute compiled program function */
 	uc_value_t *last_expression_result = NULL;
-	int return_code = uc_vm_execute(&vm, progfunc, &last_expression_result);
+	int return_code = uc_vm_execute(&vm, program, &last_expression_result);
 
 	/* handle return status */
 	switch (return_code) {

--- a/examples/execute-string.c
+++ b/examples/execute-string.c
@@ -28,7 +28,7 @@
 
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
-static const char *program = MULTILINE_STRING(
+static const char *program_code = MULTILINE_STRING(
 	{%
 		function add(a, b) {
 			c = a + b;
@@ -55,17 +55,17 @@ int main(int argc, char **argv)
 	int exit_code = 0;
 
 	/* create a source buffer containing the program code */
-	uc_source_t *src = uc_source_new_buffer("my program", strdup(program), strlen(program));
+	uc_source_t *src = uc_source_new_buffer("my program", strdup(program_code), strlen(program_code));
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -84,7 +84,10 @@ int main(int argc, char **argv)
 
 	/* execute compiled program function */
 	uc_value_t *last_expression_result = NULL;
-	int return_code = uc_vm_execute(&vm, progfunc, &last_expression_result);
+	int return_code = uc_vm_execute(&vm, program, &last_expression_result);
+
+	/* release program */
+	uc_program_put(program);
 
 	/* handle return status */
 	switch (return_code) {

--- a/examples/native-function.c
+++ b/examples/native-function.c
@@ -23,7 +23,7 @@
 
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
-static const char *program = MULTILINE_STRING(
+static const char *program_code = MULTILINE_STRING(
 	{%
 		print("add() = " + add(5, 3.1, 2) + "\n");
 		print("multiply() = " + multiply(7.3, 5) + "\n");
@@ -61,17 +61,17 @@ int main(int argc, char **argv)
 	int exit_code = 0;
 
 	/* create a source buffer containing the program code */
-	uc_source_t *src = uc_source_new_buffer("my program", strdup(program), strlen(program));
+	uc_source_t *src = uc_source_new_buffer("my program", strdup(program_code), strlen(program_code));
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -89,7 +89,10 @@ int main(int argc, char **argv)
 	uc_function_register(uc_vm_scope_get(&vm), "multiply", multiply_two_numbers);
 
 	/* execute program function */
-	int return_code = uc_vm_execute(&vm, progfunc, NULL);
+	int return_code = uc_vm_execute(&vm, program, NULL);
+
+	/* release program */
+	uc_program_put(program);
 
 	/* handle return status */
 	if (return_code == ERROR_COMPILE || return_code == ERROR_RUNTIME) {

--- a/examples/state-reset.c
+++ b/examples/state-reset.c
@@ -23,7 +23,7 @@
 
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
-static const char *program = MULTILINE_STRING(
+static const char *program_code = MULTILINE_STRING(
 	{%
 		/* the global test variable should've been reset since the previous run */
 		print("Global variable is null? " + (global.test == null) + "\n");
@@ -43,17 +43,17 @@ int main(int argc, char **argv)
 	int exit_code = 0;
 
 	/* create a source buffer containing the program code */
-	uc_source_t *src = uc_source_new_buffer("my program", strdup(program), strlen(program));
+	uc_source_t *src = uc_source_new_buffer("my program", strdup(program_code), strlen(program_code));
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -70,11 +70,8 @@ int main(int argc, char **argv)
 
 		printf("Iteration %d: ", i + 1);
 
-		/* take additional reference to progfunc to avoid freeing it after execution */
-		ucv_get(&progfunc->header);
-
 		/* execute program function */
-		int return_code = uc_vm_execute(&vm, progfunc, NULL);
+		int return_code = uc_vm_execute(&vm, program, NULL);
 
 		/* handle return status */
 		if (return_code == ERROR_COMPILE || return_code == ERROR_RUNTIME) {
@@ -88,7 +85,7 @@ int main(int argc, char **argv)
 	}
 
 	/* release program function */
-	ucv_put(&progfunc->header);
+	uc_program_put(program);
 
 	return exit_code;
 }

--- a/examples/state-reuse.c
+++ b/examples/state-reuse.c
@@ -23,7 +23,7 @@
 
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
-static const char *program = MULTILINE_STRING(
+static const char *program_code = MULTILINE_STRING(
 	{%
 		let n = global.value || 1;
 
@@ -44,17 +44,17 @@ int main(int argc, char **argv)
 	int exit_code = 0;
 
 	/* create a source buffer containing the program code */
-	uc_source_t *src = uc_source_new_buffer("my program", strdup(program), strlen(program));
+	uc_source_t *src = uc_source_new_buffer("my program", strdup(program_code), strlen(program_code));
 
 	/* compile source buffer into function */
 	char *syntax_error = NULL;
-	uc_function_t *progfunc = uc_compile(&config, src, &syntax_error);
+	uc_program_t *program = uc_compile(&config, src, &syntax_error);
 
 	/* release source buffer */
 	uc_source_put(src);
 
 	/* check if compilation failed */
-	if (!progfunc) {
+	if (!program) {
 		fprintf(stderr, "Failed to compile program: %s\n", syntax_error);
 
 		return 1;
@@ -71,11 +71,8 @@ int main(int argc, char **argv)
 	for (int i = 0; i < 5; i++) {
 		printf("Iteration %d: ", i + 1);
 
-		/* take additional reference to progfunc to avoid freeing it after execution */
-		ucv_get(&progfunc->header);
-
 		/* execute program function */
-		int return_code = uc_vm_execute(&vm, progfunc, NULL);
+		int return_code = uc_vm_execute(&vm, program, NULL);
 
 		/* handle return status */
 		if (return_code == ERROR_COMPILE || return_code == ERROR_RUNTIME) {
@@ -89,7 +86,7 @@ int main(int argc, char **argv)
 	}
 
 	/* release program function */
-	ucv_put(&progfunc->header);
+	uc_program_put(program);
 
 	/* free VM context */
 	uc_vm_free(&vm);

--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -114,7 +114,7 @@ typedef struct uc_compiler {
 	uc_upvals_t upvals;
 	uc_patchlist_t *patchlist;
 	uc_exprstack_t *exprstack;
-	uc_value_t *function;
+	uc_function_t *function;
 	uc_parser_t *parser;
 	uc_program_t *program;
 	size_t scope_depth, current_srcpos, last_insn;
@@ -126,7 +126,7 @@ typedef struct {
 	uc_precedence_t precedence;
 } uc_parse_rule_t;
 
-uc_function_t *uc_compile(uc_parse_config_t *config, uc_source_t *source, char **errp);
+uc_program_t *uc_compile(uc_parse_config_t *config, uc_source_t *source, char **errp);
 
 #define uc_compiler_exprstack_push(compiler, token, flags) \
 	uc_exprstack_t expr = { compiler->exprstack, flags, token }; \

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -22,11 +22,36 @@
 
 uc_program_t *uc_program_new(uc_source_t *);
 
-void uc_program_free(uc_program_t *);
+static inline uc_program_t *
+uc_program_get(uc_program_t *prog) {
+	return (uc_program_t *)ucv_get(prog ? &prog->header : NULL);
+}
 
-uc_value_t *uc_program_function_new(uc_program_t *, const char *, size_t);
-size_t uc_program_function_id(uc_program_t *, uc_value_t *);
-uc_value_t *uc_program_function_load(uc_program_t *, size_t);
+static inline void
+uc_program_put(uc_program_t *prog) {
+	ucv_put(prog ? &prog->header : NULL);
+}
+
+#define uc_program_function_foreach(prog, fn)			\
+	uc_function_t *fn;									\
+	for (fn = (uc_function_t *)prog->functions.prev;	\
+	     fn != (uc_function_t *)&prog->functions; 		\
+	     fn = (uc_function_t *)fn->progref.prev)
+
+#define uc_program_function_foreach_safe(prog, fn)		\
+	uc_function_t *fn, *fn##_tmp;						\
+	for (fn = (uc_function_t *)prog->functions.prev, 	\
+	     fn##_tmp = (uc_function_t *)fn->progref.prev;	\
+	     fn != (uc_function_t *)&prog->functions; 		\
+	     fn = fn##_tmp, 								\
+	     fn##_tmp = (uc_function_t *)fn##_tmp->progref.prev)
+
+uc_function_t *uc_program_function_new(uc_program_t *, const char *, size_t);
+size_t uc_program_function_id(uc_program_t *, uc_function_t *);
+uc_function_t *uc_program_function_load(uc_program_t *, size_t);
+size_t uc_program_function_srcpos(uc_function_t *, size_t);
+void uc_program_function_free(uc_function_t *);
+
 
 uc_value_t *uc_program_get_constant(uc_program_t *, size_t);
 ssize_t uc_program_add_constant(uc_program_t *, uc_value_t *);

--- a/include/ucode/source.h
+++ b/include/ucode/source.h
@@ -37,8 +37,15 @@ uc_source_t *uc_source_new_buffer(const char *name, char *buf, size_t len);
 
 size_t uc_source_get_line(uc_source_t *source, size_t *offset);
 
-uc_source_t *uc_source_get(uc_source_t *source);
-void uc_source_put(uc_source_t *source);
+static inline uc_source_t *
+uc_source_get(uc_source_t *source) {
+	return (uc_source_t *)ucv_get(source ? &source->header : NULL);
+}
+
+static inline void
+uc_source_put(uc_source_t *source) {
+	ucv_put(source ? &source->header : NULL);
+}
 
 uc_source_type_t uc_source_type_test(uc_source_t *source);
 

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -36,11 +36,11 @@ typedef enum uc_type {
 	UC_ARRAY,
 	UC_OBJECT,
 	UC_REGEXP,
-	UC_FUNCTION,
 	UC_CFUNCTION,
 	UC_CLOSURE,
 	UC_UPVALUE,
-	UC_RESOURCE
+	UC_RESOURCE,
+	UC_PROGRAM
 } uc_type_t;
 
 typedef struct uc_value {
@@ -106,6 +106,17 @@ typedef struct uc_weakref {
 	struct uc_weakref *next;
 } uc_weakref_t;
 
+typedef struct uc_function {
+	uc_weakref_t progref;
+	bool arrow, vararg, strict;
+	size_t nargs;
+	size_t nupvals;
+	size_t srcpos;
+	uc_chunk_t chunk;
+	struct uc_program *program;
+	char name[];
+} uc_function_t;
+
 typedef struct {
 	uc_value_t header;
 	double dbl;
@@ -146,18 +157,6 @@ typedef struct {
 	bool icase, newline, global;
 	char source[];
 } uc_regexp_t;
-
-typedef struct uc_function {
-	uc_value_t header;
-	bool arrow, vararg, strict, root;
-	size_t nargs;
-	size_t nupvals;
-	size_t srcpos;
-	uc_chunk_t chunk;
-	struct uc_program *program;
-	uc_weakref_t progref;
-	char name[];
-} uc_function_t;
 
 typedef struct uc_upval_tref {
 	uc_value_t header;
@@ -202,6 +201,7 @@ uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
 /* Program structure definitions */
 
 typedef struct uc_program {
+	uc_value_t header;
 	uc_value_list_t constants;
 	uc_weakref_t functions;
 	uc_source_t *source;
@@ -349,9 +349,6 @@ size_t ucv_object_length(uc_value_t *);
 	                    entry_next##key = entry##key->next, entry##key)							\
 	                 : 0);																		\
 	     entry##key = entry_next##key)
-
-uc_value_t *ucv_function_new(const char *, size_t, uc_program_t *);
-size_t ucv_function_srcpos(uc_value_t *, size_t);
 
 uc_value_t *ucv_cfunction_new(const char *, uc_cfn_ptr_t);
 

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -40,7 +40,8 @@ typedef enum uc_type {
 	UC_CLOSURE,
 	UC_UPVALUE,
 	UC_RESOURCE,
-	UC_PROGRAM
+	UC_PROGRAM,
+	UC_SOURCE
 } uc_type_t;
 
 typedef struct uc_value {
@@ -66,9 +67,10 @@ typedef struct {
 uc_declare_vector(uc_lineinfo_t, uint8_t);
 
 typedef struct {
+	uc_value_t header;
 	char *filename, *runpath, *buffer;
 	FILE *fp;
-	size_t usecount, off;
+	size_t off;
 	uc_lineinfo_t lineinfo;
 } uc_source_t;
 

--- a/include/ucode/vallist.h
+++ b/include/ucode/vallist.h
@@ -37,8 +37,7 @@ typedef enum {
 	TAG_LNUM = 2,
 	TAG_DBL = 3,
 	TAG_STR = 4,
-	TAG_LSTR = 5,
-	TAG_FUNC = 6
+	TAG_LSTR = 5
 } uc_value_type_t;
 
 uc_value_t *uc_number_parse(const char *buf, char **end);

--- a/include/ucode/vm.h
+++ b/include/ucode/vm.h
@@ -24,6 +24,7 @@
 #include "util.h"
 #include "lexer.h"
 #include "types.h"
+#include "program.h"
 
 #define __insns \
 __insn(NOOP) \
@@ -139,7 +140,7 @@ uc_exception_type_t uc_vm_call(uc_vm_t *vm, bool mcall, size_t nargs);
 void __attribute__((format(printf, 3, 0)))
 uc_vm_raise_exception(uc_vm_t *vm, uc_exception_type_t type, const char *fmt, ...);
 
-uc_vm_status_t uc_vm_execute(uc_vm_t *vm, uc_function_t *fn, uc_value_t **retval);
+uc_vm_status_t uc_vm_execute(uc_vm_t *vm, uc_program_t *fn, uc_value_t **retval);
 uc_value_t *uc_vm_invoke(uc_vm_t *vm, const char *fname, size_t nargs, ...);
 
 #endif /* __VM_H_ */

--- a/main.c
+++ b/main.c
@@ -81,13 +81,13 @@ static int
 compile(uc_vm_t *vm, uc_source_t *src, FILE *precompile, bool strip)
 {
 	uc_value_t *res = NULL;
-	uc_function_t *entry;
+	uc_program_t *program;
 	int rc = 0;
 	char *err;
 
-	entry = uc_compile(vm->config, src, &err);
+	program = uc_compile(vm->config, src, &err);
 
-	if (!entry) {
+	if (!program) {
 		fprintf(stderr, "%s", err);
 		free(err);
 		rc = -1;
@@ -95,13 +95,12 @@ compile(uc_vm_t *vm, uc_source_t *src, FILE *precompile, bool strip)
 	}
 
 	if (precompile) {
-		uc_program_write(entry->program, precompile, !strip);
-		uc_program_free(entry->program);
+		uc_program_write(program, precompile, !strip);
 		fclose(precompile);
 		goto out;
 	}
 
-	rc = uc_vm_execute(vm, entry, &res);
+	rc = uc_vm_execute(vm, program, &res);
 
 	switch (rc) {
 	case STATUS_OK:
@@ -122,6 +121,7 @@ compile(uc_vm_t *vm, uc_source_t *src, FILE *precompile, bool strip)
 	}
 
 out:
+	uc_program_put(program);
 	ucv_put(res);
 
 	return rc;

--- a/source.c
+++ b/source.c
@@ -31,12 +31,14 @@ uc_source_new_file(const char *path)
 		return NULL;
 
 	src = xalloc(ALIGN(sizeof(*src)) + strlen(path) + 1);
+
+	src->header.type = UC_SOURCE;
+	src->header.refcount = 1;
+
 	src->fp = fp;
 	src->buffer = NULL;
 	src->filename = strcpy((char *)src + ALIGN(sizeof(*src)), path);
 	src->runpath = src->filename;
-
-	src->usecount = 1;
 
 	src->lineinfo.count = 0;
 	src->lineinfo.entries = NULL;
@@ -54,11 +56,13 @@ uc_source_new_buffer(const char *name, char *buf, size_t len)
 		return NULL;
 
 	src = xalloc(ALIGN(sizeof(*src)) + strlen(name) + 1);
+
+	src->header.type = UC_SOURCE;
+	src->header.refcount = 1;
+
 	src->fp = fp;
 	src->buffer = buf;
 	src->filename = strcpy((char *)src + ALIGN(sizeof(*src)), name);
-
-	src->usecount = 1;
 
 	src->lineinfo.count = 0;
 	src->lineinfo.entries = NULL;
@@ -89,38 +93,6 @@ uc_source_get_line(uc_source_t *source, size_t *offset)
 	}
 
 	return 0;
-}
-
-uc_source_t *
-uc_source_get(uc_source_t *source)
-{
-	if (!source)
-		return NULL;
-
-	source->usecount++;
-
-	return source;
-}
-
-void
-uc_source_put(uc_source_t *source)
-{
-	if (!source)
-		return;
-
-	if (source->usecount > 1) {
-		source->usecount--;
-
-		return;
-	}
-
-	if (source->runpath != source->filename)
-		free(source->runpath);
-
-	uc_vector_clear(&source->lineinfo);
-	fclose(source->fp);
-	free(source->buffer);
-	free(source);
 }
 
 uc_source_type_t

--- a/types.c
+++ b/types.c
@@ -51,11 +51,11 @@ ucv_typename(uc_value_t *uv)
 	case UC_ARRAY:     return "array";
 	case UC_OBJECT:    return "object";
 	case UC_REGEXP:    return "regexp";
-	case UC_FUNCTION:  return "function";
 	case UC_CFUNCTION: return "cfunction";
 	case UC_CLOSURE:   return "closure";
 	case UC_UPVALUE:   return "upvalue";
 	case UC_RESOURCE:  return "resource";
+	case UC_PROGRAM:   return "program";
 	}
 
 	return "unknown";
@@ -167,7 +167,7 @@ ucv_gc_mark(uc_value_t *uv)
 		for (i = 0; i < function->nupvals; i++)
 			ucv_gc_mark(&closure->upvals[i]->header);
 
-		ucv_gc_mark(&function->header);
+		ucv_gc_mark(&function->program->header);
 
 		break;
 
@@ -196,6 +196,7 @@ ucv_free(uc_value_t *uv, bool retain)
 	uc_resource_t *resource;
 	uc_function_t *function;
 	uc_closure_t *closure;
+	uc_program_t *program;
 	uc_upvalref_t *upval;
 	uc_regexp_t *regexp;
 	uc_object_t *object;
@@ -237,19 +238,6 @@ ucv_free(uc_value_t *uv, bool retain)
 		regfree(&regexp->regexp);
 		break;
 
-	case UC_FUNCTION:
-		function = (uc_function_t *)uv;
-
-		if (function->program) {
-			ucv_unref(&function->progref);
-
-			if (function->root)
-				uc_program_free(function->program);
-		}
-
-		uc_chunk_free(&function->chunk);
-		break;
-
 	case UC_CLOSURE:
 		closure = (uc_closure_t *)uv;
 		function = closure->function;
@@ -258,7 +246,7 @@ ucv_free(uc_value_t *uv, bool retain)
 		for (i = 0; i < function->nupvals; i++)
 			ucv_put_value(&closure->upvals[i]->header, retain);
 
-		ucv_put_value(&function->header, retain);
+		ucv_put_value(&function->program->header, retain);
 		break;
 
 	case UC_RESOURCE:
@@ -273,6 +261,16 @@ ucv_free(uc_value_t *uv, bool retain)
 	case UC_UPVALUE:
 		upval = (uc_upvalref_t *)uv;
 		ucv_put_value(upval->value, retain);
+		break;
+
+	case UC_PROGRAM:
+		program = (uc_program_t *)uv;
+
+		uc_program_function_foreach_safe(program, func)
+			uc_program_function_free(func);
+
+		uc_vallist_free(&program->constants);
+		uc_source_put(program->source);
 		break;
 	}
 
@@ -950,48 +948,6 @@ ucv_object_length(uc_value_t *uv)
 
 
 uc_value_t *
-ucv_function_new(const char *name, size_t srcpos, uc_program_t *program)
-{
-	size_t namelen = 0;
-	uc_function_t *fn;
-
-	if (name)
-		namelen = strlen(name);
-
-	fn = xalloc(sizeof(*fn) + namelen + 1);
-	fn->header.type = UC_FUNCTION;
-	fn->header.refcount = 1;
-
-	if (name)
-		strcpy(fn->name, name);
-
-	fn->nargs = 0;
-	fn->nupvals = 0;
-	fn->srcpos = srcpos;
-	fn->program = program;
-	fn->vararg = false;
-
-	uc_chunk_init(&fn->chunk);
-
-	return &fn->header;
-}
-
-size_t
-ucv_function_srcpos(uc_value_t *uv, size_t off)
-{
-	uc_function_t *fn = (uc_function_t *)uv;
-	size_t pos;
-
-	if (ucv_type(uv) != UC_FUNCTION)
-		return 0;
-
-	pos = uc_chunk_debug_get_srcpos(&fn->chunk, off);
-
-	return pos ? fn->srcpos + pos : 0;
-}
-
-
-uc_value_t *
 ucv_cfunction_new(const char *name, uc_cfn_ptr_t fptr)
 {
 	uc_cfunction_t *cfn;
@@ -1028,7 +984,7 @@ ucv_closure_new(uc_vm_t *vm, uc_function_t *function, bool arrow_fn)
 	if (vm)
 		ucv_ref(&vm->values, &closure->ref);
 
-	ucv_get(&function->header);
+	uc_program_get(function->program);
 
 	return &closure->header;
 }
@@ -1370,9 +1326,9 @@ ucv_to_json(uc_value_t *uv)
 
 	case UC_CLOSURE:
 	case UC_CFUNCTION:
-	case UC_FUNCTION:
 	case UC_RESOURCE:
 	case UC_UPVALUE:
+	case UC_PROGRAM:
 	case UC_NULL:
 		return NULL;
 	}
@@ -1691,14 +1647,6 @@ ucv_to_stringbuf_formatted(uc_vm_t *vm, uc_stringbuf_t *pb, uc_value_t *uv, size
 
 		break;
 
-	case UC_FUNCTION:
-		ucv_stringbuf_printf(pb, "%s<function %p>%s",
-			json ? "\"" : "",
-			uv,
-			json ? "\"" : "");
-
-		break;
-
 	case UC_RESOURCE:
 		resource = (uc_resource_t *)uv;
 		restype = resource->type;
@@ -1718,6 +1666,12 @@ ucv_to_stringbuf_formatted(uc_vm_t *vm, uc_stringbuf_t *pb, uc_value_t *uv, size
 			json ? "\"" : "");
 
 		break;
+
+	case UC_PROGRAM:
+		ucv_stringbuf_printf(pb, "%s<program %p>%s",
+			json ? "\"" : "",
+			uv,
+			json ? "\"" : "");
 	}
 
 	ucv_clear_mark(uv);

--- a/vallist.c
+++ b/vallist.c
@@ -465,16 +465,6 @@ find_str(uc_value_list_t *list, const char *s, size_t slen)
 	return -1;
 }
 
-static void
-add_func(uc_value_list_t *list, uc_function_t *func)
-{
-	size_t id = uc_program_function_id(func->program, &func->header);
-
-	assert(id != 0 && TAG_FIT_NV(id));
-
-	list->index[list->isize++] = (TAG_TYPE)(TAG_FUNC | TAG_SET_NV(id));
-}
-
 ssize_t
 uc_vallist_add(uc_value_list_t *list, uc_value_t *value)
 {
@@ -525,10 +515,6 @@ uc_vallist_add(uc_value_list_t *list, uc_value_t *value)
 
 		break;
 
-	case UC_FUNCTION:
-		add_func(list, (uc_function_t *)value);
-		break;
-
 	default:
 		return -1;
 	}
@@ -545,15 +531,10 @@ uc_vallist_type(uc_value_list_t *list, size_t idx)
 	return TAG_GET_TYPE(list->index[idx]);
 }
 
-#define container_of(ptr, type, member) ({                      \
-        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
-        (type *)( (char *)__mptr - offsetof(type,member) );})
-
 uc_value_t *
 uc_vallist_get(uc_value_list_t *list, size_t idx)
 {
 	char str[sizeof(TAG_TYPE)];
-	uc_program_t *program;
 	size_t n, len;
 
 	switch (uc_vallist_type(list, idx)) {
@@ -590,11 +571,6 @@ uc_vallist_get(uc_value_list_t *list, size_t idx)
 			return NULL;
 
 		return ucv_string_new_length(list->data + TAG_GET_OFFSET(list->index[idx]) + sizeof(uint32_t), len);
-
-	case TAG_FUNC:
-		program = container_of(list, uc_program_t, constants);
-
-		return uc_program_function_load(program, TAG_GET_NV(list->index[idx]));
 
 	default:
 		return NULL;


### PR DESCRIPTION
 - Instead of treating individual program functions as managed ucode types,
   demote uc_function_t values to pointers into a uc_program_t entity

 - Promote uc_program_t to a managed type

 - Let uc_closure_t claim references to the owning program of the enclosed
   uc_function_t

 - Redefine public APIs uc_compile() and uc_vm_execute() APIs to return and
   expect an uc_program_t object respectively

 - Remove vallist indirection for function loading and let the compiler
   emit the function id directly when producing function construction code

Signed-off-by: Jo-Philipp Wich <jo@mein.io>