### PR TITLE
util: allow usage of json.h if JSONC is defiend

### DIFF
--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -23,7 +23,11 @@
 #include <stdbool.h>
 #include <stdarg.h> /* va_start(), va_end(), va_list */
 #include <string.h> /* strdup() */
-#include <json-c/json.h>
+#ifdef JSONC
+	#include <json.h>
+#else
+	#include <json-c/json.h>
+#endif
 
 
 /* alignment & array size */


### PR DESCRIPTION
This was already applied in main.c, compiler.h and vallist.h.

Signed-off-by: Paul Spooren <mail@aparcar.org>