### PR TITLE
endian: support apple endian.h

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -23,7 +23,11 @@
 #include <regex.h>
 #include <math.h>
 #include <errno.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 
 #include "ucode/vm.h"
 #include "ucode/lib.h"

--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -24,7 +24,11 @@ limitations under the License.
 #include <limits.h>
 #include <math.h>
 #include <assert.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 #include <fcntl.h>
 #include <poll.h>
 

--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -24,7 +24,11 @@ limitations under the License.
 #include <limits.h>
 #include <math.h>
 #include <assert.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 
 #include <netinet/ether.h>
 #include <arpa/inet.h>

--- a/program.c
+++ b/program.c
@@ -16,7 +16,11 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 
 #include "ucode/program.h"
 #include "ucode/source.h"

--- a/source.c
+++ b/source.c
@@ -16,7 +16,11 @@
 
 #include <string.h>
 #include <errno.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 
 #include "ucode/source.h"
 

--- a/types.c
+++ b/types.c
@@ -17,7 +17,11 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <endian.h>
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h>
+#endif
 #include <errno.h>
 #include <math.h>
 #include <ctype.h>

--- a/vallist.c
+++ b/vallist.c
@@ -15,7 +15,11 @@
  */
 
 #include <string.h> /* memcpy(), memset() */
-#include <endian.h> /* htobe64(), be64toh() */
+#if defined(__APPLE__)
+  #include <machine/endian.h>
+#else
+  #include <endian.h> /* htobe64(), be64toh() */
+#endif
 #include <math.h> /* isnan(), INFINITY */
 #include <ctype.h> /* isspace(), isdigit(), isxdigit() */
 #include <assert.h>


### PR DESCRIPTION
Apple uses a different include path for endian.h.

Signed-off-by: Paul Spooren <mail@aparcar.org>