### PR TITLE
fix TYPES_H definition on macOS

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef __TYPES_H_
-#define __TYPES_H_
+#ifndef __UC_TYPES_H_
+#define __UC_TYPES_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -501,4 +501,4 @@ void ucv_gc(uc_vm_t *);
 
 void ucv_freeall(uc_vm_t *);
 
-#endif /* __TYPES_H_ */
+#endif /* __UC_TYPES_H_ */


### PR DESCRIPTION
The definition __TYPES_H_ is already defined via types.h on macOS[1],
therefore non of the ucode specific definitions are added.

[1]: https://opensource.apple.com/source/Libc/Libc-825.26/include/_types.h.auto.html

Signed-off-by: Paul Spooren <mail@aparcar.org>