### PR TITLE
ubus: add object publishing, notify and subscribe support

### DIFF
--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -111,6 +111,7 @@ uc_uloop_run(uc_vm_t *vm, size_t nargs)
 	uc_value_t *timeout = uc_fn_arg(0);
 	int t, rv;
 
+	errno = 0;
 	t = timeout ? (int)ucv_int64_get(timeout) : -1;
 
 	if (errno)
@@ -182,6 +183,7 @@ uc_uloop_timer_set(uc_vm_t *vm, size_t nargs)
 	if (!timer || !*timer)
 		err_return(EINVAL);
 
+	errno = 0;
 	t = timeout ? (int)ucv_int64_get(timeout) : -1;
 
 	if (errno)
@@ -243,6 +245,7 @@ uc_uloop_timer(uc_vm_t *vm, size_t nargs)
 	uc_value_t *res;
 	int t;
 
+	errno = 0;
 	t = timeout ? ucv_int64_get(timeout) : -1;
 
 	if (errno)


### PR DESCRIPTION
Extend the ubus binding to cover ubus object publishing, notifications on
objects, as well as subscriber APIs.

Instantiating ubus objects:

    obj = conn.publish("objname", {
        methodname: {
            args: { ...argspec... },
            call: function(request) { ...method handler... }
        },
        ...
    }, function() { ...subscription status change handler... });

    obj.notify(...);
    obj.remove();

Emitting notifications:

    obj.notify("notificationtype", { ...notification data... },
        function(type, data) { ...data callback... },
        function(idx, ret) { ...status callback... },
        function() { ...completion callback... },
        100 /* timeout */
    );

Instantiating subscribers:

    sub = conn.subscriber(
        function(notify) { ...notification handler... },
        function(id) { ...object gone handler... }
    );

    sub.subscribe("objname");
    sub.unsubscribe("objname");
    sub.remove();

Signed-off-by: Jo-Philipp Wich <jo@mein.io>