### PR TITLE
vm: fix crash on object literals with non-string computed properties

### DIFF
--- a/tests/custom/04_bugs/33_vm_computed_prop_decl_crash
+++ b/tests/custom/04_bugs/33_vm_computed_prop_decl_crash
@@ -1,0 +1,17 @@
+When executing an object literal declaration using non-string computed
+property name values, the VM crashed caused by an attempt to use a NULL
+pointer (result of ucv_string_get() on a non-string value) as hash table
+key.
+
+-- Testcase --
+{%
+	printf("%.J\n", { [1]: "test", [true]: "foo" });
+%}
+-- End --
+
+-- Expect stdout --
+{
+	"1": "test",
+	"true": "foo"
+}
+-- End --

--- a/vm.c
+++ b/vm.c
@@ -1804,15 +1804,12 @@ static void
 uc_vm_insn_sobj(uc_vm_t *vm, uc_vm_insn_t insn)
 {
 	uc_value_t *obj = uc_vm_stack_peek(vm, vm->arg.u32);
-	uc_value_t *val;
 	size_t idx;
 
-	for (idx = 0; idx < vm->arg.u32; idx += 2) {
-		val = uc_vm_stack_peek(vm, vm->arg.u32 - idx - 1);
-		ucv_object_add(obj,
-			ucv_string_get(val),
-			ucv_get(uc_vm_stack_peek(vm, vm->arg.u32 - idx - 2)));
-	}
+	for (idx = 0; idx < vm->arg.u32; idx += 2)
+		ucv_key_set(vm, obj,
+			uc_vm_stack_peek(vm, vm->arg.u32 - idx - 1),
+			uc_vm_stack_peek(vm, vm->arg.u32 - idx - 2));
 
 	for (idx = 0; idx < vm->arg.u32; idx++)
 		ucv_put(uc_vm_stack_pop(vm));


### PR DESCRIPTION
When executing an object literal declaration using non-string computed
property name values, the VM crashed caused by an attempt to use a NULL
pointer (result of ucv_string_get() on a non-string value) as hash table
key.

Fix this issue by using the `ucv_key_set()` infrastructure which deals
with the implicit stringification of non-string key values.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>