### PR TITLE
lib: provide API function to obtain stdlib function implementations

### DIFF
--- a/include/ucode/lib.h
+++ b/include/ucode/lib.h
@@ -29,6 +29,7 @@ typedef struct {
 extern const uc_function_list_t uc_stdlib_functions[];
 
 void uc_stdlib_load(uc_value_t *scope);
+uc_cfn_ptr_t uc_stdlib_function(const char *name);
 
 bool uc_source_context_format(uc_stringbuf_t *buf, uc_source_t *src, size_t off, bool compact);
 bool uc_error_context_format(uc_stringbuf_t *buf, uc_source_t *src, uc_value_t *stacktrace, size_t off);

--- a/lib.c
+++ b/lib.c
@@ -3194,3 +3194,15 @@ uc_stdlib_load(uc_value_t *scope)
 {
 	uc_function_list_register(scope, uc_stdlib_functions);
 }
+
+uc_cfn_ptr_t
+uc_stdlib_function(const char *name)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(uc_stdlib_functions); i++)
+		if (!strcmp(uc_stdlib_functions[i].name, name))
+			return uc_stdlib_functions[i].func;
+
+	return NULL;
+}


### PR DESCRIPTION
Provide a new API function `uc_stdlib_function()` which allows to fetch
the C implementation of the given named standard library function.

This is useful for loadable modules or applications that embed ucode which
want to reuse core functions such as `sprintf()`.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>