### PR TITLE
fs: fix off-by-one in fs.dirname() function

### DIFF
--- a/lib/fs.c
+++ b/lib/fs.c
@@ -948,7 +948,7 @@ uc_fs_dirname(uc_vm_t *vm, size_t nargs)
 		if (i == 0)
 			return ucv_string_new("/");
 
-	return ucv_string_new_length(s, i);
+	return ucv_string_new_length(s, i + 1);
 }
 
 static uc_value_t *

--- a/tests/custom/04_bugs/34_dirname_off_by_one
+++ b/tests/custom/04_bugs/34_dirname_off_by_one
@@ -1,0 +1,16 @@
+Make sure fs.dirname() doesn't truncate the last character of the
+returned path. Previously ucv_string_new_length was called with a
+length which no longer included the last character (which had just
+been tested not to be a '/' or '.' and hence broke the loop at that
+point).
+
+-- Testcase --
+{%
+	fs = require('fs');
+	printf("%s\n", fs.dirname('/etc/config/wireless'));
+%}
+-- End --
+
+-- Expect stdout --
+/etc/config
+-- End --


### PR DESCRIPTION
Make sure fs.dirname() doesn't truncate the last character of the
returned path. Previously ucv_string_new_length was called with a
length which no longer included the last character (which had just
been tested not to be a '/' or '.' and hence broke the loop at that
point).

Signed-off-by: Daniel Golle <daniel@makrotopia.org>