### PR TITLE
treewide: move json-c compat shims into internal header file

### DIFF
--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <json-c/json.h>
 
 #include "source.h"
 #include "lexer.h"

--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -159,30 +159,4 @@ static inline struct printbuf *xprintbuf_new(void) {
 	return pb;
 }
 
-
-/* json-c compat */
-
-#ifndef HAVE_PARSE_END
-static inline size_t json_tokener_get_parse_end(struct json_tokener *tok) {
-	return (size_t)tok->char_offset;
-}
-#endif
-
-#ifndef HAVE_ARRAY_EXT
-static inline struct json_object *json_object_new_array_ext(int size) {
-	(void) size;
-	return json_object_new_array();
-}
-#endif
-
-#ifndef HAVE_JSON_UINT64
-static inline struct json_object *json_object_new_uint64(uint64_t i) {
-	return json_object_new_int64((int64_t)i);
-}
-
-static inline uint64_t json_object_get_uint64(const struct json_object *obj) {
-	return (uint64_t)json_object_get_int64(obj);
-}
-#endif
-
 #endif /* UCODE_UTIL_H */

--- a/include/ucode/vallist.h
+++ b/include/ucode/vallist.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <json-c/json.h>
 
 #include "types.h"
 

--- a/json-c-compat.h
+++ b/json-c-compat.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Jo-Philipp Wich <jo@mein.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef JSON_C_COMPAT_H
+#define JSON_C_COMPAT_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <json-c/json.h>
+
+
+/* json-c compat */
+
+#ifndef HAVE_PARSE_END
+static inline size_t json_tokener_get_parse_end(struct json_tokener *tok) {
+	return (size_t)tok->char_offset;
+}
+#endif
+
+#ifndef HAVE_ARRAY_EXT
+static inline struct json_object *json_object_new_array_ext(int size) {
+	(void) size;
+	return json_object_new_array();
+}
+#endif
+
+#ifndef HAVE_JSON_UINT64
+static inline struct json_object *json_object_new_uint64(uint64_t i) {
+	return json_object_new_int64((int64_t)i);
+}
+
+static inline uint64_t json_object_get_uint64(const struct json_object *obj) {
+	return (uint64_t)json_object_get_int64(obj);
+}
+#endif
+
+#endif /* JSON_C_COMPAT_H */

--- a/lib.c
+++ b/lib.c
@@ -33,6 +33,8 @@
 #include <fnmatch.h>
 #include <assert.h>
 
+#include "json-c-compat.h"
+
 #include "ucode/lexer.h"
 #include "ucode/compiler.h"
 #include "ucode/vm.h"

--- a/main.c
+++ b/main.c
@@ -23,7 +23,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <json-c/json.h>
+
+#include "json-c-compat.h"
 
 #include "ucode/compiler.h"
 #include "ucode/lexer.h"

--- a/types.c
+++ b/types.c
@@ -23,6 +23,8 @@
 #include <ctype.h>
 #include <float.h>
 
+#include "json-c-compat.h"
+
 #include "ucode/types.h"
 #include "ucode/util.h"
 #include "ucode/vm.h"


### PR DESCRIPTION
Do not expose the json-c compat functions in ucode's public headers to
avoid clashes when building on systems with modern json-c.

Also remove some explicit json-c/json-c.h includes in places where it is
not needed.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>