### PR TITLE
ci: make jobs faster during pull request testing

### DIFF
--- a/.github/workflows/openwrt-ci-master.yml
+++ b/.github/workflows/openwrt-ci-master.yml
@@ -1,6 +1,10 @@
-name: OpenWrt CI testing
+name: OpenWrt CI master branch testing
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+
 env:
   CI_ENABLE_UNIT_TESTING: 1
   CI_TARGET_BUILD_DEPENDS: libnl-tiny ubus uci
@@ -13,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.1
+      - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.2
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/openwrt-ci-pull-request.yml
+++ b/.github/workflows/openwrt-ci-pull-request.yml
@@ -1,0 +1,56 @@
+name: OpenWrt CI pull request testing
+
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+
+env:
+  CI_ENABLE_UNIT_TESTING: 1
+  CI_TARGET_BUILD_DEPENDS: libnl-tiny ubus uci
+
+jobs:
+  native_testing:
+    name: Various native checks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.2
+        env:
+          CI_GCC_VERSION_LIST:
+          CI_CLANG_VERSION_LIST: 11
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: native-build-artifacts
+          if-no-files-found: ignore
+          path: |
+            build/scan
+            tests/cram/**/*.t.err
+
+  sdk_build:
+    name: Build with OpenWrt ${{ matrix.sdk_platform }} SDK (out of tree)
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk_platform:
+          - ath79-generic
+          - imx6-generic
+          - malta-be
+          - mvebu-cortexa53
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
+        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.1
+        env:
+          CI_TARGET_SDK_RELEASE: master
+          CI_TARGET_SDK_IMAGE: ${{ matrix.sdk_platform }}


### PR DESCRIPTION
With the proliferation of test cases, CI runs tend to become rather long
since we run all tests under valgrind using multiple gcc and Clang
versions each.

In order to speedup the jobs, we tests pull requests under the most
recent Clang versions and run all tests when the code hits the master
branch.

Closes #66
Signed-off-by: Petr Štetiar <ynezz@true.cz>