### PR TITLE
Number literals

### DIFF
--- a/include/ucode/vallist.h
+++ b/include/ucode/vallist.h
@@ -34,6 +34,7 @@ typedef enum {
 } uc_value_type_t;
 
 uc_value_t *uc_number_parse(const char *buf, char **end);
+uc_value_t *uc_number_parse_octal(const char *buf, char **end);
 
 bool uc_double_pack(double d, char *buf, bool little_endian);
 double uc_double_unpack(const char *buf, bool little_endian);

--- a/lib.c
+++ b/lib.c
@@ -570,7 +570,22 @@ uc_hex(uc_vm_t *vm, size_t nargs)
 static uc_value_t *
 uc_int(uc_vm_t *vm, size_t nargs)
 {
-	int64_t n = ucv_to_integer(uc_fn_arg(0));
+	uc_value_t *val = uc_fn_arg(0);
+	uc_value_t *base = uc_fn_arg(1);
+	char *e, *v;
+	int64_t n;
+
+	if (ucv_type(val) == UC_STRING) {
+		errno = 0;
+		v = ucv_string_get(val);
+		n = strtoll(v, &e, base ? ucv_int64_get(base) : 10);
+
+		if (e == v)
+			return ucv_double_new(NAN);
+	}
+	else {
+		n = ucv_to_integer(val);
+	}
 
 	if (errno == EINVAL || errno == ERANGE)
 		return ucv_double_new(NAN);

--- a/tests/custom/00_syntax/10_numeric_literals
+++ b/tests/custom/00_syntax/10_numeric_literals
@@ -8,6 +8,8 @@ doubles internally.
 -- Expect stdout --
 Integers literals: 123, 127, 2748, 57082
 Float literals: 10, 10.3, 1.23456e-65, 16.0625
+Octal literals: 63, 118
+Binary literals: 7, 11
 Special values: Infinity, Infinity, NaN, NaN
 Minimum values: -9223372036854775808, -1.79769e+308
 Maximum values: 9223372036854775807, 1.79769e+308
@@ -18,6 +20,8 @@ Maximum truncation: 18446744073709551615, Infinity
 -- Testcase --
 Integers literals: {{ 123 }}, {{ 0177 }}, {{ 0xabc }}, {{ 0xDEFA }}
 Float literals: {{ 10. }}, {{ 10.3 }}, {{ 123.456e-67 }}, {{ 0x10.1 }}
+Octal literals: {{ 0o77 }}, {{ 0O166 }}
+Binary literals: {{ 0b111 }}, {{ 0B1011 }}
 Special values: {{ Infinity }}, {{ 1 / 0 }}, {{ NaN }}, {{ "x" / 1 }}
 Minimum values: {{ -9223372036854775808 }}, {{ -1.7976931348623158e+308 }}
 Maximum values: {{ 9223372036854775807 }}, {{ 1.7976931348623158e+308 }}

--- a/tests/custom/03_stdlib/08_int
+++ b/tests/custom/03_stdlib/08_int
@@ -1,8 +1,9 @@
 The `int()` function converts the given value into a signed integer
-value and returns the resulting number.
+value and returns the resulting number. In case the value is of type
+string, a second optional base argument may be specified which is
+passed to the underlying strtoll(3) implementation.
 
 Returns `NaN` if the given argument is not convertible into a number.
-
 Returns `NaN` if the conversion result is out of range.
 
 -- Testcase --
@@ -19,7 +20,11 @@ Returns `NaN` if the conversion result is out of range.
 		int("0xffffffffffffffff"),
 		int("0177"),
 		int("+145"),
-		int("-96")
+		int("-96"),
+		int("0177", 8),
+		int("0x1000", 16),
+		int("1111", 2),
+		int("0xffffffffffffffff", 16)
 	]);
 %}
 -- End --
@@ -37,6 +42,10 @@ Returns `NaN` if the conversion result is out of range.
 	0,
 	177,
 	145,
-	-96
+	-96,
+	127,
+	4096,
+	15,
+	"NaN"
 ]
 -- End --

--- a/tests/custom/03_stdlib/08_int
+++ b/tests/custom/03_stdlib/08_int
@@ -30,13 +30,13 @@ Returns `NaN` if the conversion result is out of range.
 	0,
 	123,
 	456,
+	"NaN",
+	"NaN",
+	"NaN",
 	0,
-	"NaN",
-	"NaN",
-	4096,
-	"NaN",
-	127,
-	"NaN",
+	0,
+	177,
+	145,
 	-96
 ]
 -- End --

--- a/tests/custom/04_bugs/29_empty_string_as_number
+++ b/tests/custom/04_bugs/29_empty_string_as_number
@@ -1,16 +1,14 @@
-When an empty string was casted to a number, e.g. explicitly through `+`
-or `int()` or implicitly through numerical calculations, it was incorrectly
-treated as `NaN` and not `0`.
+When an empty string was explicitly casted to a number through `+` or
+implicitly through numerical calculations, it was incorrectly treated
+as `NaN` and not `0`.
 
 -- Testcase --
 {{ +"" }}
-{{ int("") }}
 {{ "" + 0 }}
 {{ "" - 0.0 }}
 -- End --
 
 -- Expect stdout --
-0
 0
 0
 0


### PR DESCRIPTION
-  syntax: adjust number literal parsing and string to number conversion
    
     - Recognize new number literal prefixes `0o` and `0O` for octal as well
       as `0b` and `0B` for binary number literals
    
     - Treat number literals with leading zeros as octal while parsing but
       as decimal ones on implicit number conversions, means `012` will yield
       `10` while `+"012"` or `"012" + 0` will yield `12`

-  lib: refactor `uc_int()`
    
    For string cases, turn `int()` into a thin `strtoll()` wrapper which
    attempts to parse the initial portion of the string as a decimal integer
    literal, optionally preceded by white space and a sign character.
    
    Also introduce an optional `base` argument for string cases while we're
    at it and adjust the existing stdlib test case accordingly.
    
    The function now behaves mostly the same as ECMAScript `parseInt(val, 10)`
    for string cases, means it will recognize `012` as `12` and not `10` and
    it will accept trailing non-digit characters after the initial portition
    of the input string.
