### PR TITLE
rtnl: avoid stray "netlink: %d bytes leftover after parsing attributes."

### DIFF
--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -1345,10 +1345,13 @@ uc_nl_convert_attrs(struct nl_msg *msg, void *buf, size_t buflen, size_t headsiz
 	if (!tb)
 		return false;
 
-	if (buflen > headsize)
-		nla_parse(tb, maxattr, buf + headsize, buflen - headsize, NULL);
-	else
+	if (buflen > headsize) {
+		if (maxattr)
+			nla_parse(tb, maxattr, buf + headsize, buflen - headsize, NULL);
+	}
+	else {
 		structlen = buflen;
+	}
 
 	for (i = 0; i < nattrs; i++) {
 		if (attrs[i].attr == 0 && (uintptr_t)attrs[i].auxdata >= structlen)


### PR DESCRIPTION
Some nested RTAs such as IFLA_INET_CONF do not contain actual sub-RTAs but
just an array of integers. Avoid calling a no-op `nla_parse()` for such
attributes to suppress the non-harmful leftover bytes warning emitted by
libnl.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>