### PR TITLE
rtnl: fix premature netlink reply receive abort

### DIFF
--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -3087,10 +3087,7 @@ cb_reply(struct nl_msg *msg, void *arg)
 		}
 	}
 
-	if (hdr->nlmsg_flags & NLM_F_MULTI)
-		s->state = STATE_CONTINUE;
-	else
-		s->state = STATE_REPLIED;
+	s->state = STATE_CONTINUE;
 
 	return NL_SKIP;
 }
@@ -3186,6 +3183,7 @@ uc_nl_request(uc_vm_t *vm, size_t nargs)
 
 	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, cb_reply, &st);
 	nl_cb_set(cb, NL_CB_FINISH, NL_CB_CUSTOM, cb_done, &st);
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, cb_done, &st);
 	nl_cb_err(cb, NL_CB_CUSTOM, cb_error, &st);
 
 	nl_send_auto_complete(sock, msg);
@@ -3199,7 +3197,7 @@ uc_nl_request(uc_vm_t *vm, size_t nargs)
 			st.state = STATE_ERROR;
 		}
 	}
-	while (st.state == STATE_CONTINUE);
+	while (st.state < STATE_REPLIED);
 
 	nlmsg_free(msg);
 	nl_cb_put(cb);


### PR DESCRIPTION
The nl_recvmsgs() logic in uc_nl_request() incorrectly stopped reading
the socket before the netlink ACK message was handled for non-multipart
replies.

This caused subsequent requests to incorrectly receive the ACK of the
previous request, leading to a failure to receive the actual reply.

Fix this issue by continue reading the socket until either the finish
callback for multipart (dump) messages or the ack callback for non-
multipart messages was received.

This fix is basically the same as the one applied to the nl80211 module
in 54ef6c0 ("nl80211: fix premature netlink reply receive abort").

Signed-off-by: Jo-Philipp Wich <jo@mein.io>