### PR TITLE
rtnl: fix segmentation fault on parsing linkinfo RTA without data

### DIFF
--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -1890,8 +1890,9 @@ uc_nl_convert_rta_linkinfo_data(uc_value_t *obj, size_t attr, struct nl_msg *msg
 		}
 	}
 
-	if (nattrs > 0) {
-		attr = (attr == IFLA_INFO_KIND) ? IFLA_INFO_DATA : IFLA_INFO_SLAVE_DATA;
+	attr = (attr == IFLA_INFO_KIND) ? IFLA_INFO_DATA : IFLA_INFO_SLAVE_DATA;
+
+	if (nattrs > 0 && tb[attr]) {
 		rv = uc_nl_convert_attrs(msg, nla_data(tb[attr]), nla_len(tb[attr]), 0, attrs, nattrs, vm, obj);
 
 		if (!rv)


### PR DESCRIPTION
Some link types, such as veth, yield an IFLA_LINKINFO nla without an
embedded IFLA_INFO_DATA / INFLA_INFO_SLAVE_DATA nla which causes the
nla converter to dereference a NULL nla pointer.

Properly deal with such cases and check for the existence of the
child nla before attempting to parse it.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>