### PR TITLE
compiler: fix stack mismatch on nonmatching switch statements with lo…

### DIFF
--- a/tests/custom/04_bugs/11_switch_stack_mismatch
+++ b/tests/custom/04_bugs/11_switch_stack_mismatch
@@ -37,3 +37,30 @@ Matching 3:
 	}
 %}
 -- End --
+
+-- Expect stdout --
+Matching 1:
+Matching 2:
+ - 2: [ 3, 4 ]
+ - 3: [ 3, 4, 5, 6 ]
+Matching 3:
+ - 3: [ null, null, 5, 6 ]
+-- End --
+
+-- Testcase --
+{%
+	for (let n in [1, 2, 3]) {
+		printf("Matching %d:\n", n);
+
+		switch (n) {
+			case 2:
+				let a = 3, b = 4;
+				print(" - 2: ", [a, b], "\n");
+
+			case 3:
+				let c = 5, d = 6;
+				print(" - 3: ", [a, b, c, d], "\n");
+		}
+	}
+%}
+-- End --


### PR DESCRIPTION
…cals

When a switch statement containing cases with local variable declarations
and no default case is evalulated and none of the the cases matched, the
local variable slots were never initialized but got popped off the stack
when execution resumed after the switch scope, leading to a mismatch in
stack layout between compiler and runtime, causing local variables to
yield wrong values or a stack underflow triggering a segmentation fault.

Solve this issue by patching the last conditional case match jump to hop
beyond the local variable pop instructions when no default case is defined.

Also extend the regression test case dealing with other switch related
stack mismatch issues to cover this particular problem as well.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>