### PR TITLE
nl80211: fix NL80211_SURVEY_INFO_NOISE datatype

### DIFF
--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -772,7 +772,7 @@ static const uc_nl_nested_spec_t nl80211_survey_info_nla = {
 		{ NL80211_SURVEY_INFO_TIME_BUSY, "busy", DT_U64, 0, NULL },
 		{ NL80211_SURVEY_INFO_TIME_EXT_BUSY, "ext_busy", DT_U64, 0, NULL },
 		{ NL80211_SURVEY_INFO_TIME_SCAN, "scan", DT_U64, 0, NULL },
-		{ NL80211_SURVEY_INFO_NOISE, "noise", DT_U8, 0, NULL },
+		{ NL80211_SURVEY_INFO_NOISE, "noise", DT_S8, 0, NULL },
 	}
 };
 


### PR DESCRIPTION
Report the noise value as signed integer to calling ucode.

Reported-by: John Crispin <john@phrozen.org>
Signed-off-by: Jo-Philipp Wich <jo@mein.io>