### PR TITLE
lexer: fix parsing with disabled block left stripping

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -887,9 +887,12 @@ lex_step(uc_lexer_t *lex, FILE *fp)
 				buf_consume(lex, 1);
 			}
 
-			/* global block lstrip */
-			else if (lex->config && lex->config->lstrip_blocks) {
-				rv = lookbehind_to_text(lex, lex->source->off, TK_TEXT, " \t\v\f\r");
+			/* put out text leading up to the opening tag and potentially
+			 * strip trailing white space from it depending on the global
+			 * block lstrip setting */
+			else {
+				rv = lookbehind_to_text(lex, lex->source->off, TK_TEXT,
+					(lex->config && lex->config->lstrip_blocks) ? " \t\v\f\r" : NULL);
 			}
 		}
 		else {

--- a/tests/custom/04_bugs/40_lexer_bug_on_lstrip_off
+++ b/tests/custom/04_bugs/40_lexer_bug_on_lstrip_off
@@ -1,0 +1,20 @@
+When a template was parsed with global block left stripping disabled,
+then any text preceding an expression or statement block start tag was
+incorrectly prepended to the first token value of the block, leading
+to syntax errors in the compiler.
+
+-- Testcase --
+{% for (let x in [1, 2, 3]): %}
+{{ x }}
+{% endfor %}
+-- End --
+
+-- Args --
+-Tno-lstrip
+-- End --
+
+-- Expect stdout --
+1
+2
+3
+-- End --


### PR DESCRIPTION
When a template was parsed with global block left stripping disabled, then
any text preceding an expression or statement block start tag was incorrectly
prepended to the first token value of the block, leading to syntax errors in
the compiler.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>