### PR TITLE
Module import export fixes

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -3169,14 +3169,14 @@ uc_compiler_compile_module_source(uc_compiler_t *compiler, uc_source_t *source, 
 }
 
 static char *
-uc_compiler_canonicalize_path(const char *path, const char *basedir)
+uc_compiler_canonicalize_path(const char *path, const char *runpath)
 {
 	char *p, *resolved;
 
 	if (*path == '/')
 		xasprintf(&p, "%s", path);
-	else if (basedir)
-		xasprintf(&p, "%s/%s", basedir, path);
+	else if (runpath && (p = strrchr(runpath, '/')) != NULL)
+		xasprintf(&p, "%.*s/%s", (int)(p - runpath), runpath, path);
 	else
 		xasprintf(&p, "./%s", path);
 
@@ -3188,7 +3188,7 @@ uc_compiler_canonicalize_path(const char *path, const char *basedir)
 }
 
 static char *
-uc_compiler_expand_module_path(const char *name, const char *basedir, const char *template)
+uc_compiler_expand_module_path(const char *name, const char *runpath, const char *template)
 {
 	int namelen, prefixlen;
 	char *path, *p;
@@ -3207,7 +3207,7 @@ uc_compiler_expand_module_path(const char *name, const char *basedir, const char
 		if (*p == '.')
 			*p = '/';
 
-	p = uc_compiler_canonicalize_path(path, basedir);
+	p = uc_compiler_canonicalize_path(path, runpath);
 
 	free(path);
 

--- a/compiler.c
+++ b/compiler.c
@@ -3484,6 +3484,10 @@ uc_compile_from_source(uc_parse_config_t *config, uc_source_t *source, uc_progra
 	uc_compiler_init(&compiler, name, source, 0, progptr,
 		config && config->strict_declarations);
 
+	if (progptr == prog) {
+		compiler.function->module = true;
+	}
+
 	uc_compiler_parse_advance(&compiler);
 
 	while (!uc_compiler_parse_match(&compiler, TK_EOF))

--- a/compiler.c
+++ b/compiler.c
@@ -2809,6 +2809,12 @@ uc_compiler_compile_return(uc_compiler_t *compiler)
 	uc_chunk_t *chunk = uc_compiler_current_chunk(compiler);
 	size_t off = chunk->count;
 
+	if (compiler->function->module) {
+		uc_compiler_syntax_error(compiler, 0, "return must be inside function body");
+
+		return;
+	}
+
 	uc_compiler_compile_expstmt(compiler);
 
 	/* if we compiled an empty expression statement (`;`), load implicit null */
@@ -3009,7 +3015,7 @@ uc_compiler_compile_export(uc_compiler_t *compiler)
 	uc_value_t *name;
 	ssize_t slot;
 
-	if (compiler->program->sources.count == 1 || compiler->scope_depth) {
+	if (!compiler->function->module || compiler->scope_depth) {
 		uc_compiler_syntax_error(compiler, compiler->parser->prev.pos,
 			"Exports may only appear at top level of a module");
 

--- a/include/ucode/program.h
+++ b/include/ucode/program.h
@@ -55,8 +55,6 @@ __hidden uc_source_t *uc_program_function_source(uc_function_t *);
 __hidden size_t uc_program_function_srcpos(uc_function_t *, size_t);
 __hidden void uc_program_function_free(uc_function_t *);
 
-__hidden ssize_t uc_program_export_lookup(uc_program_t *, uc_source_t *, uc_value_t *);
-
 __hidden uc_value_t *uc_program_get_constant(uc_program_t *, size_t);
 __hidden ssize_t uc_program_add_constant(uc_program_t *, uc_value_t *);
 

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -65,7 +65,6 @@ typedef struct {
 /* Source buffer defintions */
 
 uc_declare_vector(uc_lineinfo_t, uint8_t);
-uc_declare_vector(uc_exports_t, uc_value_t *);
 
 typedef struct {
 	uc_value_t header;
@@ -73,7 +72,10 @@ typedef struct {
 	FILE *fp;
 	size_t off;
 	uc_lineinfo_t lineinfo;
-	uc_exports_t exports;
+	struct {
+		size_t count, offset;
+		uc_value_t **entries;
+	} exports;
 } uc_source_t;
 
 

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -112,7 +112,7 @@ typedef struct uc_weakref {
 
 typedef struct uc_function {
 	uc_weakref_t progref;
-	bool arrow, vararg, strict;
+	bool arrow, vararg, strict, module;
 	size_t nargs;
 	size_t nupvals;
 	size_t srcidx;

--- a/program.c
+++ b/program.c
@@ -851,24 +851,3 @@ uc_program_entry(uc_program_t *program)
 
 	return (uc_function_t *)program->functions.prev;
 }
-
-ssize_t
-uc_program_export_lookup(uc_program_t *program, uc_source_t *source, uc_value_t *name)
-{
-	size_t i, off;
-	ssize_t slot;
-
-	for (i = 0, off = 0; i < program->sources.count; i++) {
-		if (program->sources.entries[i] != source) {
-			off += program->sources.entries[i]->exports.count;
-			continue;
-		}
-
-		slot = uc_source_export_lookup(source, name);
-
-		if (slot > -1)
-			return off + slot;
-	}
-
-	return -1;
-}

--- a/program.c
+++ b/program.c
@@ -228,6 +228,7 @@ enum {
 	UC_FUNCTION_F_HAS_NAME       = (1 << 4),
 	UC_FUNCTION_F_HAS_VARDBG     = (1 << 5),
 	UC_FUNCTION_F_HAS_OFFSETDBG  = (1 << 6),
+	UC_FUNCTION_F_IS_MODULE      = (1 << 7),
 };
 
 static void
@@ -287,6 +288,9 @@ write_function(uc_function_t *func, FILE *file, bool debug)
 
 	if (func->strict)
 		flags |= UC_FUNCTION_F_IS_STRICT;
+
+	if (func->module)
+		flags |= UC_FUNCTION_F_IS_MODULE;
 
 	if (func->chunk.ehranges.count)
 		flags |= UC_FUNCTION_F_HAS_EXCEPTIONS;
@@ -780,6 +784,7 @@ read_function(FILE *file, uc_program_t *program, size_t idx, char **errp)
 	func->arrow   = (flags & UC_FUNCTION_F_IS_ARROW);
 	func->vararg  = (flags & UC_FUNCTION_F_IS_VARARG);
 	func->strict  = (flags & UC_FUNCTION_F_IS_STRICT);
+	func->module  = (flags & UC_FUNCTION_F_IS_MODULE);
 	func->nargs   = nargs;
 	func->nupvals = nupvals;
 

--- a/tests/custom/04_modules/06_export_errors
+++ b/tests/custom/04_modules/06_export_errors
@@ -36,15 +36,14 @@ import "./files/test.uc";
 
 -- Expect stderr --
 Syntax error: Unable to compile module './files/test.uc':
-Syntax error: Exports may only appear at top level of a module
-In line 2, byte 2:
 
- `    export let x = 1;`
-      ^-- Near here
+  | Syntax error: Exports may only appear at top level of a module
+  | In ./files/test.uc, line 2, byte 2:
+  |
+  |  `    export let x = 1;`
+  |       ^-- Near here
 
-
-
-In line 1, byte 25:
+In [stdin], line 1, byte 25:
 
  `import "./files/test.uc";`
   Near here --------------^
@@ -72,15 +71,14 @@ export { y as x };
 
 -- Expect stderr --
 Syntax error: Unable to compile module './files/test-duplicate.uc':
-Syntax error: Duplicate export 'x' for module './files/test-duplicate.uc'
-In line 4, byte 15:
 
- `export { y as x };`
-  Near here ----^
+  | Syntax error: Duplicate export 'x' for module './files/test-duplicate.uc'
+  | In ./files/test-duplicate.uc, line 4, byte 15:
+  |
+  |  `export { y as x };`
+  |   Near here ----^
 
-
-
-In line 1, byte 35:
+In [stdin], line 1, byte 35:
 
  `import "./files/test-duplicate.uc";`
   Near here ------------------------^

--- a/tests/custom/04_modules/07_import_default
+++ b/tests/custom/04_modules/07_import_default
@@ -39,7 +39,7 @@ export const x = "This is a non-default export";
 
 -- Expect stderr --
 Syntax error: Module ./files/test2.uc has no default export
-In line 1, byte 20:
+In [stdin], line 1, byte 20:
 
  `import defVal from "./files/test2.uc";`
   Near here ---------^

--- a/tests/custom/04_modules/08_import_list
+++ b/tests/custom/04_modules/08_import_list
@@ -38,7 +38,7 @@ export const x = "This is a test";
 
 -- Expect stderr --
 Syntax error: Module ./files/test2.uc has no default export
-In line 1, byte 15:
+In [stdin], line 1, byte 15:
 
  `import y from "./files/test2.uc";`
   Near here ----^

--- a/tests/custom/04_modules/12_import_immutability
+++ b/tests/custom/04_modules/12_import_immutability
@@ -16,7 +16,7 @@ export let a = 1;
 
 -- Expect stderr --
 Syntax error: Invalid assignment to constant 'a'
-In line 3, byte 5:
+In [stdin], line 3, byte 5:
 
  `a = 2;`
       ^-- Near here

--- a/tests/custom/04_modules/14_circular_imports
+++ b/tests/custom/04_modules/14_circular_imports
@@ -1,0 +1,43 @@
+Circular imports are not possible and will lead to a compilation error.
+
+-- Testcase --
+import a_val from "./files/a.uc";
+-- End --
+
+-- File a.uc --
+import b_val from "./b.uc";
+export default "a";
+-- End --
+
+-- File b.uc --
+import a_val from "./a.uc";
+export default "b";
+-- End --
+
+-- Args --
+-R
+-- End --
+
+-- Expect stderr --
+Syntax error: Unable to compile module './files/a.uc':
+
+  | Syntax error: Unable to compile module './files/b.uc':
+  |
+  |   | Syntax error: Circular dependency
+  |   | In ./files/b.uc, line 1, byte 19:
+  |   |
+  |   |  `import a_val from "./a.uc";`
+  |   |   Near here --------^
+  |
+  | In ./files/a.uc, line 1, byte 27:
+  |
+  |  `import b_val from "./b.uc";`
+  |   Near here ----------------^
+
+In [stdin], line 1, byte 33:
+
+ `import a_val from "./files/a.uc";`
+  Near here ----------------------^
+
+
+-- End --

--- a/tests/custom/04_modules/15_complex_imports
+++ b/tests/custom/04_modules/15_complex_imports
@@ -1,0 +1,151 @@
+This testcase implements a somewhat complex dependency chain to stress
+test the compiler module resolving.
+
+The dependency tree is:
+
+root
+ + mod1
+    + mod4
+    + mod8
+ + mod2
+    + mod4
+    + mod6
+    + mod8
+    + mod9
+ + mod3
+    + mod4
+    + mod6
+ + mod4
+ + mod5
+    + mod1
+       + mod4
+       + mod8
+    + mod2
+       + mod4
+       + mod6
+       + mod8
+       + mod9
+    + mod4
+    + mod6
+    + mod8
+    + mod9
+       + mod4
+       + mod6
+ + mod6
+ + mod7
+    + mod5
+       + mod1
+          + mod4
+          + mod8
+       + mod2
+          + mod4
+          + mod6
+          + mod8
+          + mod9
+       + mod4
+       + mod6
+       + mod8
+       + mod9
+          + mod4
+          + mod6
+    + mod6
+ + mod8
+
+-- Testcase --
+import mod1 from 'mod1';
+import mod2 from 'mod2';
+import mod3 from 'mod3';
+import mod4 from 'mod4';
+import mod5 from 'mod5';
+import mod6 from 'mod6';
+import mod7 from 'mod7';
+import mod8 from 'mod8';
+
+print("root: ", [ mod1, mod2, mod3, mod4, mod5, mod6, mod7, mod8 ], "\n");
+-- End --
+
+-- File mod1.uc --
+import mod4 from 'mod4';
+import mod8 from 'mod8';
+
+print("mod1: ", [ mod4, mod8 ], "\n");
+
+export default 'mod1';
+-- End --
+
+-- File mod2.uc --
+import mod9 from 'mod9';
+import mod4 from 'mod4';
+import mod8 from 'mod8';
+import mod6 from 'mod6';
+
+print("mod2: ", [ mod4, mod6, mod8, mod9 ], "\n");
+
+export default 'mod2';
+-- End --
+
+-- File mod3.uc --
+import mod4 from 'mod4';
+import mod6 from 'mod6';
+
+print("mod3: ", [ mod4, mod6 ], "\n");
+
+export default 'mod3';
+-- End --
+
+-- File mod4.uc --
+export default 'mod4';
+-- End --
+
+-- File mod5.uc --
+import mod1 from 'mod1';
+import mod4 from 'mod4';
+import mod2 from 'mod2';
+import mod9 from 'mod9';
+import mod8 from 'mod8';
+import mod6 from 'mod6';
+
+print("mod5: ", [ mod1, mod2, mod4, mod6, mod8, mod9 ], "\n");
+
+export default 'mod5';
+-- End --
+
+-- File mod6.uc --
+export default 'mod6';
+-- End --
+
+-- File mod7.uc --
+import mod6 from 'mod6';
+import mod5 from 'mod5';
+
+print("mod7: ", [ mod5, mod6 ], "\n");
+
+export default 'mod7';
+-- End --
+
+-- File mod8.uc --
+export default 'mod8';
+-- End --
+
+-- File mod9.uc --
+import mod4 from 'mod4';
+import mod6 from 'mod6';
+
+print("mod9: ", [ mod4, mod6 ], "\n");
+
+export default 'mod9';
+-- End --
+
+-- Args --
+-R -L files/
+-- End --
+
+-- Expect stdout --
+mod1: [ "mod4", "mod8" ]
+mod9: [ "mod4", "mod6" ]
+mod2: [ "mod4", "mod6", "mod8", "mod9" ]
+mod3: [ "mod4", "mod6" ]
+mod5: [ "mod1", "mod2", "mod4", "mod6", "mod8", "mod9" ]
+mod7: [ "mod5", "mod6" ]
+root: [ "mod1", "mod2", "mod3", "mod4", "mod5", "mod6", "mod7", "mod8" ]
+-- End --

--- a/vm.c
+++ b/vm.c
@@ -1179,6 +1179,9 @@ uc_vm_insn_load_closure(uc_vm_t *vm, uc_vm_insn_t insn)
 
 	uc_vm_stack_push(vm, &closure->header);
 
+	if (function->module)
+		return;
+
 	for (i = 0; i < function->nupvals; i++) {
 		uv = (
 			frame->ip[0] * 0x1000000 +


### PR DESCRIPTION
This PR introduces a series of fixes for the compilation of import and export statements.

 - Fixes segmentation fault on loading and executing module constructors containing import upvals
 - Fixes allocating export registry slots in the compiler
 - Stricter compilation rules for modules
 - Fixed relative module path resolving
 - Improved error message formatting