### PR TITLE
ubus: mitigate possible strncpy string truncation

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -1461,7 +1461,7 @@ uc_ubus_object_register(struct ubus_context *ctx, const char *ubus_object_name,
 	method = (struct ubus_method *)mptr;
 
 	obj = &uuobj->obj;
-	obj->name = strncpy(onptr, ubus_object_name, namelen);
+	obj->name = strncpy(onptr, ubus_object_name, namelen - 1);
 	obj->methods = method;
 
 	if (ubus_object_methods) {


### PR DESCRIPTION
gcc 10 with -O2 reports following:

```make
 In function ‘strncpy’,
     inlined from ‘uc_ubus_object_register’ at /ucode/lib/ubus.c:1464:14,
     inlined from ‘uc_ubus_publish’ at /ucode/lib/ubus.c:1521:10:
 /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
   106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Since it is not possible to avoid truncation by strncpy, it is necessary
to make sure the result of strncpy is properly NUL-terminated and the
NUL must be inserted explicitly, after strncpy has returned.

References: https://github.com/openwrt/openwrt/issues/10442
Reported-by: [alexeys85](https://github.com/alexeys85)