### PR TITLE
Various improvements

### DIFF
--- a/tests/cram/test_basic.t
+++ b/tests/cram/test_basic.t
@@ -22,6 +22,9 @@ check that ucode provides exepected help:
   -e "expression"
     Execute the given expression as ucode program.
   
+  -p "expression"
+    Like `-e` but print the result of expression.
+  
   -t
     Enable VM execution tracing.
   
@@ -85,7 +88,7 @@ check that ucode prints greetings:
 check that ucode provides proper error messages:
 
   $ touch lib.uc; ucode -l lib
-  Require either -e expression or source file
+  Require either -e/-p expression or source file
   [1]
 
   $ ucode -l foo -e ' '
@@ -101,7 +104,7 @@ check that ucode provides proper error messages:
 check that ucode can load fs module:
 
   $ ucode -l fs
-  Require either -e expression or source file
+  Require either -e/-p expression or source file
   [1]
 
   $ ucode -l fs -e ' '

--- a/tests/custom/00_syntax/21_regex_literals
+++ b/tests/custom/00_syntax/21_regex_literals
@@ -4,7 +4,7 @@ within regular expression literals is subject of the underlying
 regular expression engine.
 
 -- Expect stdout --
-[ "/Hello world/", "/test/gis", "/test/g", "/test1 \\\/ test2/", "/\\x31\n\\.\u0007\b\\c\\u2600\\\\/" ]
+[ "/Hello world/", "/test/gis", "/test/g", "/test1 / test2/", "/1\n\\.\u0007\bc☀\\\\/" ]
 -- End --
 
 -- Testcase --
@@ -91,5 +91,29 @@ In line 7, byte 30:
 		if (e.type == "Syntax error")
 			die("Catched syntax error");
 	}
+%}
+-- End --
+
+
+Testing that slashes within character classes are not treated as regex
+literal delimitters.
+
+-- Expect stdout --
+[
+	"/[/]/",
+	"/[[./.]/]/",
+	"/[[:alpha:]/]/",
+	"/[[=/=]/]/"
+]
+-- End --
+
+-- Testcase --
+{%
+	printf("%.J\n", [
+		/[/]/,
+		/[[./.]/]/,
+		/[[:alpha:]/]/,
+		/[[=/=]/]/
+	]);
 %}
 -- End --

--- a/tests/custom/99_bugs/41_compiler_invalid_return_opcode
+++ b/tests/custom/99_bugs/41_compiler_invalid_return_opcode
@@ -1,0 +1,20 @@
+When compiling an arrow function body with a trailing loop or conditional
+statement having an empty body, the emitted return code incorrectly
+overwrote the target address of the jump instruction.
+
+-- Testcase --
+(() => {
+	if(0)
+		;
+})();
+
+print("OK\n");
+-- End --
+
+-- Args --
+-R
+-- End --
+
+-- Expect stdout --
+OK
+-- End --

--- a/types.c
+++ b/types.c
@@ -1431,9 +1431,6 @@ ucv_to_string_json_encoded(uc_stringbuf_t *pb, const char *s, size_t len, bool r
 			break;
 
 		case '/':
-			if (regexp)
-				ucv_stringbuf_append(pb, "\\");
-
 			ucv_stringbuf_append(pb, "/");
 			break;
 


### PR DESCRIPTION
1. main: implement print mode

Introduce a new `-p` flag which works like `-e` but prints the final
expression result.

---

2. compiler: optimize function return opcode generation

Track last emitted statement type in compiled code and only generate final
`return null` opcodes if there is no preceeding `return` statement.

Also use this statement tracking to avoid emitting invalid return opcodes
for arrow function bodies with trailing empty statements.

---
  
3. lexer: improve regex literal handling

 - Do not treat slashes within bracket expressions as delimitters
 - Do not escape slashes when stringifying regex sources
