### PR TITLE
lexer: fixes for regex literal parsing

### DIFF
--- a/tests/custom/00_syntax/21_regex_literals
+++ b/tests/custom/00_syntax/21_regex_literals
@@ -4,7 +4,7 @@ within regular expression literals is subject of the underlying
 regular expression engine.
 
 -- Expect stdout --
-[ "/Hello world/", "/test/gis", "/test/g", "/test1 / test2/", "/1\n\\.\u0007\bc☀\\\\/" ]
+[ "/Hello world/", "/test/gis", "/test/g", "/test1 / test2/", "/1\n\\.\u0007\\bc☀\\\\/" ]
 -- End --
 
 -- Testcase --
@@ -114,6 +114,33 @@ literal delimitters.
 		/[[./.]/]/,
 		/[[:alpha:]/]/,
 		/[[=/=]/]/
+	]);
+%}
+-- End --
+
+
+Testing that regex extension macros are substituted only outside of
+bracket set expressions.
+
+-- Expect stdout --
+[
+	"/ \\b \\B [\b B] /",
+	"/ \\< \\> [< >] /",
+	"/ [[:digit:]] [^[:digit:]] [d D] /",
+	"/ [[:space:]] [^[:space:]] [s S] /",
+	"/ [[:alnum:]_] [^[:alnum:]_] [w W] /"
+]
+-- End --
+
+-- Testcase --
+{%
+	printf("%.J\n", [
+		/ \b \B [\b \B] /,   // \b outside brackets is a word boundary,
+		                     // \b within brackets is backspace
+		/ \< \> [\< \>] /,
+		/ \d \D [\d \D] /,
+		/ \s \S [\s \S] /,
+		/ \w \W [\w \W] /
 	]);
 %}
 -- End --


### PR DESCRIPTION
 - Ensure that regexp extension escapes are consistently handled; substitute `\d`, `\D`, `\s`, `\S`, `\w` and `\W` with `[[:digit:]]`, `[^[:digit:]]`, `[[:space:]]`, `[^[:space:]]`, `[[:alnum:]_]` and `[^[:alnum:]_]` character classes respectively since not all POSIX regexp implementations implement all of those extensions
 - Preserve `\b`, `\B`, `\<` and `\>` boundary matches

Fixes: a45f2a3 ("lexer: improve regex literal handling")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>