### PR TITLE
fs: expose `getdelim()` functionality through `fd.read()`

### DIFF
--- a/lib/fs.c
+++ b/lib/fs.c
@@ -73,8 +73,9 @@ uc_fs_read_common(uc_vm_t *vm, size_t nargs, const char *type)
 
 	if (ucv_type(limit) == UC_STRING) {
 		lstr = ucv_string_get(limit);
+		llen = ucv_string_length(limit);
 
-		if (!strcmp(lstr, "line")) {
+		if (llen == 4 && !strcmp(lstr, "line")) {
 			llen = getline(&p, &rlen, *fp);
 
 			if (llen == -1)
@@ -82,7 +83,7 @@ uc_fs_read_common(uc_vm_t *vm, size_t nargs, const char *type)
 
 			len = (size_t)llen;
 		}
-		else if (!strcmp(lstr, "all")) {
+		else if (llen == 3 && !strcmp(lstr, "all")) {
 			while (true) {
 				rlen = fread(buf, 1, sizeof(buf), *fp);
 
@@ -101,6 +102,14 @@ uc_fs_read_common(uc_vm_t *vm, size_t nargs, const char *type)
 				if (rlen == 0)
 					break;
 			}
+		}
+		else if (llen == 1) {
+			llen = getdelim(&p, &rlen, *lstr, *fp);
+
+			if (llen == -1)
+				err_return(errno);
+
+			len = (size_t)llen;
 		}
 		else {
 			return NULL;


### PR DESCRIPTION
When `fd.read()` is invoked with a single-character string argument, invoke `getdelim()` internally to read the input until the give character or EOF. This is useful for reading character delimited input data.

For example `fd.read('\n')` will read any data up to the first newline (or EOF) while `fd.read('\0x00')` will read until the first null byte.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>