### PR TITLE
add cmake to install requires for debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ packages for local installation, first install required development packages,
 then clone the repository and invoke *dpkg-buildpackage* to produce the binary
 package files:
 
-    $ sudo apt-get install build-essential devscripts debhelper libjson-c-dev
+    $ sudo apt-get install build-essential devscripts debhelper libjson-c-dev cmake
     $ git clone https://github.com/jow-/ucode.git
     $ cd ucode/
     $ dpkg-buildpackage -b -us -uc


### PR DESCRIPTION
This PR adds cmake to the install depends.

If cmake is not installed `dpkg-buildpackage -b -us -uc` fails with the following message:

```bash
Can't exec "cmake": No such file or directory at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 522.
```