### PR TITLE
compiler: ensure that arrow functions with block bodies return no value

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -1330,19 +1330,15 @@ uc_compiler_compile_arrowfn(uc_compiler_t *compiler, uc_value_t *args, bool rest
 	if (uc_compiler_parse_match(&fncompiler, TK_LBRACE)) {
 		while (!uc_compiler_parse_check(&fncompiler, TK_RBRACE) &&
 		       !uc_compiler_parse_check(&fncompiler, TK_EOF))
-			last_statement_type = uc_compiler_compile_declaration(&fncompiler);
+			uc_compiler_compile_declaration(&fncompiler);
 
 		uc_compiler_parse_consume(&fncompiler, TK_RBRACE);
 
-		/* overwrite last pop result with return */
-		if (last_statement_type == TK_SCOL)
-			uc_chunk_pop(&fn->chunk);
-
-		/* else load implicit null */
-		else
+		/* emit final return */
+		if (last_statement_type != TK_RETURN) {
 			uc_compiler_emit_insn(&fncompiler, 0, I_LNULL);
-
-		uc_compiler_emit_insn(&fncompiler, 0, I_RETURN);
+			uc_compiler_emit_insn(&fncompiler, 0, I_RETURN);
+		}
 	}
 	else {
 		uc_compiler_parse_precedence(&fncompiler, P_ASSIGN);

--- a/tests/custom/00_syntax/19_arrow_functions
+++ b/tests/custom/00_syntax/19_arrow_functions
@@ -38,7 +38,7 @@ test
 
 	// parentheses may be omitted if arrow function takes only one argument
 	test4_fn = a => {
-		a * 2;
+		return a * 2;
 	};
 
 	// curly braces may be omitted if function body is a single expression
@@ -120,5 +120,28 @@ In line 2, byte 10:
 -- Testcase --
 {%
 	(a + 1) => { print("test\n") }
+%}
+-- End --
+
+
+Arrow functions consisting of a single expression implicitly return the expression
+results. Arrow functions having a statement block as body do not return any result
+by default but may return explictly.
+
+-- Expect stdout --
+[
+	4,
+	null,
+	4
+]
+-- End --
+
+-- Testcase --
+{%
+	printf("%.J\n", [
+		(() => 2 * 2)(),
+		(() => { 2 * 2 })(),
+		(() => { return 2 * 2 })()
+	]);
 %}
 -- End --


### PR DESCRIPTION
Follow ES6 semantics and ensure that arrow functions with a block body don't implicitly return the value of the last executed statement.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>