### PR TITLE
uci: auto-load package in `ctx.foreach()` and `ctx.get_first()`

### DIFF
--- a/lib/uci.c
+++ b/lib/uci.c
@@ -346,8 +346,8 @@ uc_uci_get_first(uc_vm_t *vm, size_t nargs)
 		break;
 	}
 
-	if (!p)
-		err_return(UCI_ERR_NOTFOUND);
+	if (!p && uci_load(*c, ucv_string_get(conf), &p))
+		err_return((*c)->err);
 
 	uci_foreach_element(&p->sections, e) {
 		sc = uci_to_section(e);
@@ -917,8 +917,8 @@ uc_uci_foreach(uc_vm_t *vm, size_t nargs)
 		break;
 	}
 
-	if (!p)
-		err_return(UCI_ERR_NOTFOUND);
+	if (!p && uci_load(*c, ucv_string_get(conf), &p))
+		err_return((*c)->err);
 
 	uci_foreach_element_safe(&p->sections, tmp, e) {
 		sc = uci_to_section(e);
@@ -945,8 +945,6 @@ uc_uci_foreach(uc_vm_t *vm, size_t nargs)
 		if (stop)
 			break;
 	}
-
-	/* XXX: rethrow */
 
 	return ucv_boolean_new(ret);
 }


### PR DESCRIPTION
Functions that use `uci_lookup_ptr()` internally, such as `ctx.get()`, `ctx.set()` or `ctx.delete()`, implicitly load the given configuration name while the higher level functions `ctx.foreach()` or `ctx.get_first()` do not.

This behaviour violates the principle of least surprise and might lead to non-deterministic program behavior as the outcome of these functions depends on prior uci operations performed on the cursor.

Fix this issue by invoking `uci_load()` internally in case the given uci package name cannot be found in the cursor's package cache.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>