### PR TITLE
uloop: terminate parent uloop in task child processes

### DIFF
--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -976,6 +976,8 @@ uc_uloop_task(uc_vm_t *vm, size_t nargs)
 		err_return(errno);
 
 	if (pid == 0) {
+		uloop_done();
+
 		patch_devnull(0, false);
 		patch_devnull(1, true);
 		patch_devnull(2, true);


### PR DESCRIPTION
Ensure that the main process uloop is terminated within task child processes. Before this fix, using uloop in a task function would trigger invalid memory accesses in the parent process by notifying non-existing fd slots in the parent through the inherited shared epoll descriptor.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>