### PR TITLE
include: add uc_fn_thisval()

### DIFF
--- a/include/ucode/lib.h
+++ b/include/ucode/lib.h
@@ -38,14 +38,26 @@ __hidden void uc_error_message_indent(char **msg);
 __hidden uc_value_t *uc_require_library(uc_vm_t *vm, uc_value_t *nameval, bool so_only);
 
 /* vm helper */
+static inline uc_value_t *
+_uc_fn_this_res(uc_vm_t *vm)
+{
+	return vm->callframes.entries[vm->callframes.count - 1].ctx;
+}
 
 static inline void *
 _uc_fn_this(uc_vm_t *vm, const char *expected_type)
 {
-	return ucv_resource_dataptr(vm->callframes.entries[vm->callframes.count - 1].ctx, expected_type);
+	return ucv_resource_dataptr(_uc_fn_this_res(vm), expected_type);
+}
+
+static inline void *
+_uc_fn_thisval(uc_vm_t *vm, const char *expected_type)
+{
+	return ucv_resource_data(_uc_fn_this_res(vm), expected_type);
 }
 
 #define uc_fn_this(...) _uc_fn_this(vm, __VA_ARGS__)
+#define uc_fn_thisval(...) _uc_fn_thisval(vm, __VA_ARGS__)
 
 static inline uc_value_t *
 _uc_fn_arg(uc_vm_t *vm, size_t nargs, size_t n)

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -392,6 +392,7 @@ uc_resource_type_t *ucv_resource_type_add(uc_vm_t *, const char *, uc_value_t *,
 uc_resource_type_t *ucv_resource_type_lookup(uc_vm_t *, const char *);
 
 uc_value_t *ucv_resource_new(uc_resource_type_t *, void *);
+void *ucv_resource_data(uc_value_t *uv, const char *);
 void **ucv_resource_dataptr(uc_value_t *, const char *);
 
 uc_value_t *ucv_regexp_new(const char *, bool, bool, bool, char **);

--- a/types.c
+++ b/types.c
@@ -1096,8 +1096,8 @@ ucv_resource_new(uc_resource_type_t *type, void *data)
 	return &res->header;
 }
 
-void **
-ucv_resource_dataptr(uc_value_t *uv, const char *name)
+static uc_resource_t *
+ucv_resource_check(uc_value_t *uv, const char *name)
 {
 	uc_resource_t *res = (uc_resource_t *)uv;
 
@@ -1109,7 +1109,23 @@ ucv_resource_dataptr(uc_value_t *uv, const char *name)
 			return NULL;
 	}
 
-	return &res->data;
+	return res;
+}
+
+void *
+ucv_resource_data(uc_value_t *uv, const char *name)
+{
+	uc_resource_t *res = ucv_resource_check(uv, name);
+
+	return res ? res->data : NULL;
+}
+
+void **
+ucv_resource_dataptr(uc_value_t *uv, const char *name)
+{
+	uc_resource_t *res = ucv_resource_check(uv, name);
+
+	return res ? &res->data : NULL;
 }
 
 


### PR DESCRIPTION
Can be used to get rid of a layer of pointer indirection in resource type handlers.