### PR TITLE
nl80211: fix NL80211_ATTR_SURVEY_INFO

### DIFF
--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -807,7 +807,7 @@ static const uc_nl_nested_spec_t nl80211_mpath_info_nla = {
 
 static const uc_nl_nested_spec_t nl80211_msg = {
 	.headsize = 0,
-	.nattrs = 126,
+	.nattrs = 127,
 	.attrs = {
 		{ NL80211_ATTR_4ADDR, "4addr", DT_U8, 0, NULL },
 		{ NL80211_ATTR_AIRTIME_WEIGHT, "airtime_weight", DT_U16, 0, NULL },


### PR DESCRIPTION
This is the last attribute, adapt .nattr to include it so it gets parsed.

Signed-off-by: Andre Heider <a.heider@gmail.com>