### PR TITLE
ci: unbreak failing builds by using fixed gh-actions-openwrt-ci-sdk

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ucode/
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: |

--- a/.github/workflows/openwrt-ci-master.yml
+++ b/.github/workflows/openwrt-ci-master.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         sdk_platform:
           - ath79-generic
-          - imx6-generic
+          - imx-cortexa9
           - malta-be
           - mvebu-cortexa53
 

--- a/.github/workflows/openwrt-ci-master.yml
+++ b/.github/workflows/openwrt-ci-master.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CI_ENABLE_UNIT_TESTING: 1
   CI_TARGET_BUILD_DEPENDS: libnl-tiny ubus uci

--- a/.github/workflows/openwrt-ci-master.yml
+++ b/.github/workflows/openwrt-ci-master.yml
@@ -16,10 +16,10 @@ env:
 jobs:
   native_testing:
     name: Various native checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.2
 
@@ -35,7 +35,7 @@ jobs:
 
   sdk_build:
     name: Build with OpenWrt ${{ matrix.sdk_platform }} SDK (out of tree)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -44,10 +44,10 @@ jobs:
           - ath79-generic
           - imx-cortexa9
           - malta-be
-          - mvebu-cortexa53
+          - mediatek-mt7622
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
         uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.2

--- a/.github/workflows/openwrt-ci-master.yml
+++ b/.github/workflows/openwrt-ci-master.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
-        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.1
+        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.2
         env:
           CI_TARGET_SDK_RELEASE: master
           CI_TARGET_SDK_IMAGE: ${{ matrix.sdk_platform }}

--- a/.github/workflows/openwrt-ci-pull-request.yml
+++ b/.github/workflows/openwrt-ci-pull-request.yml
@@ -10,6 +10,10 @@ env:
   CI_ENABLE_UNIT_TESTING: 1
   CI_TARGET_BUILD_DEPENDS: libnl-tiny ubus uci
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   native_testing:
     name: Various native checks

--- a/.github/workflows/openwrt-ci-pull-request.yml
+++ b/.github/workflows/openwrt-ci-pull-request.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         sdk_platform:
           - ath79-generic
-          - imx6-generic
+          - imx-cortexa9
           - malta-be
           - mvebu-cortexa53
 

--- a/.github/workflows/openwrt-ci-pull-request.yml
+++ b/.github/workflows/openwrt-ci-pull-request.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   native_testing:
     name: Various native checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.2
         env:
@@ -39,7 +39,7 @@ jobs:
 
   sdk_build:
     name: Build with OpenWrt ${{ matrix.sdk_platform }} SDK (out of tree)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -48,10 +48,10 @@ jobs:
           - ath79-generic
           - imx-cortexa9
           - malta-be
-          - mvebu-cortexa53
+          - mediatek-mt7622
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
         uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.2

--- a/.github/workflows/openwrt-ci-pull-request.yml
+++ b/.github/workflows/openwrt-ci-pull-request.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
-        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.1
+        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.2
         env:
           CI_TARGET_SDK_RELEASE: master
           CI_TARGET_SDK_IMAGE: ${{ matrix.sdk_platform }}


### PR DESCRIPTION
SDK containers hosted under `openwrtorg` Docker organization were deprecated so lets use fixed action version v0.0.2 which uses new `openwrt` organization.

References: https://lists.openwrt.org/pipermail/openwrt-devel/2023-March/040728.html

### TODO

- [x] upgrade all deprecated actions
 * Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.