### PR TITLE
program: fix memory leak in read_sourceinfo

### DIFF
--- a/program.c
+++ b/program.c
@@ -587,8 +587,11 @@ read_sourceinfo(uc_source_t *input, uint32_t flags, char **errp, uc_program_t *p
 				return NULL;
 			}
 
-			if (!read_size_t(input->fp, &len, sizeof(uint32_t), "sourceinfo code buffer length", errp))
+			if (!read_size_t(input->fp, &len, sizeof(uint32_t), "sourceinfo code buffer length", errp)) {
+				free(path);
+
 				return NULL;
+			}
 
 			if (len > 0) {
 				code = xalloc(len);


### PR DESCRIPTION
Fix Coverty Scan CID 1521109 reporting a memory leak for path not freed on read_size_t fail.