### PR TITLE
compiler: fix memory leak in uc_compiler_compile_import on early exit

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -3602,6 +3602,7 @@ uc_compiler_compile_import(uc_compiler_t *compiler)
 		uc_compiler_syntax_error(compiler, compiler->parser->prev.pos,
 			"Imports may only appear at top level");
 
+		ucv_put(namelist);
 		return;
 	}
 


### PR DESCRIPTION
Fix Coverity Scan CID 1521107 reporting a memory leak in uc_compiler_compile_import on early exit due to namelist not correctly put before return.