### PR TITLE
Fixes for source offset tracking

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -94,9 +94,9 @@ fill_buf(uc_lexer_t *lex) {
 
 static int
 update_line(uc_lexer_t *lex, int ch) {
-	if (ch == '\n' || ch == EOF)
+	if (ch == '\n')
 		uc_source_line_next(lex->source);
-	else
+	else if (ch != EOF)
 		uc_source_line_update(lex->source, 1);
 
 	lex->source->off++;

--- a/tests/custom/03_stdlib/29_require
+++ b/tests/custom/03_stdlib/29_require
@@ -134,7 +134,7 @@ return {
 Runtime error: Unable to compile source file './files/require/test/broken.uc':
 
   | Syntax error: Expecting label
-  | In line 2, byte 10:
+  | In line 3, byte 1:
   |
   |  `return {`
   |           ^-- Near here

--- a/tests/custom/03_stdlib/35_include
+++ b/tests/custom/03_stdlib/35_include
@@ -147,7 +147,7 @@ A compilation error in the file triggers an exception.
 Runtime error: Unable to compile source file './files/broken.uc':
 
   | Syntax error: Expecting label
-  | In line 3, byte 11:
+  | In line 4, byte 1:
   |
   |  `    return {`
   |   Near here --^

--- a/tests/custom/03_stdlib/36_render
+++ b/tests/custom/03_stdlib/36_render
@@ -146,7 +146,7 @@ A compilation error in the file triggers an exception.
 Runtime error: Unable to compile source file './files/broken.uc':
 
   | Syntax error: Expecting label
-  | In line 3, byte 11:
+  | In line 4, byte 1:
   |
   |  `    return {`
   |   Near here --^

--- a/tests/custom/03_stdlib/62_loadfile
+++ b/tests/custom/03_stdlib/62_loadfile
@@ -134,7 +134,7 @@ Compiling a syntax error (should fail with syntax error exception)
 Runtime error: Unable to compile source file './files/test6.uc':
 
   | Syntax error: Expecting expression
-  | In line 1, byte 5:
+  | In line 2, byte 1:
   |
   |  `1 +`
   |      ^-- Near here

--- a/tests/custom/99_bugs/14_incomplete_expression_at_eof
+++ b/tests/custom/99_bugs/14_incomplete_expression_at_eof
@@ -3,7 +3,7 @@ buffer, the source code context line was not properly printed.
 
 -- Expect stderr --
 Syntax error: Expecting expression
-In line 1, byte 7:
+In line 2, byte 1:
 
  `{% 1+`
        ^-- Near here

--- a/tests/custom/99_bugs/25_lexer_shifted_offsets
+++ b/tests/custom/99_bugs/25_lexer_shifted_offsets
@@ -12,7 +12,7 @@ to be incorrectly shifted.
 
 -- Expect stderr --
 Error
-In line 3, byte 12:
+In line 3, byte 13:
 
  `    die("Error");`
   Near here -----^


### PR DESCRIPTION
This PR fixes a number of minor issues with the source offset tracking leading to incorrect line/byte positions when decoding debug information to obtain the declaration spot of variables or similar.

   - When skipping the interpreter line, don't count it's newline twice
   - Fix reporting byte offsets beyond the end of line
  -  Don't count EOF token as newline