### PR TITLE
Fix 165

### DIFF
--- a/lib/fs.c
+++ b/lib/fs.c
@@ -838,7 +838,7 @@ uc_fs_isatty(uc_vm_t *vm, size_t nargs)
 	if (fd == -1)
 		err_return(errno);
 
-	return ucv_boolean_new(isatty(fd));
+	return ucv_boolean_new(isatty(fd) == 1);
 }
 
 /**

--- a/types.c
+++ b/types.c
@@ -1998,7 +1998,7 @@ ucv_compare(int how, uc_value_t *v1, uc_value_t *v2, int *deltap)
 	uint64_t u1, u2;
 	int64_t n1, n2;
 	double d1, d2;
-	int8_t delta;
+	int delta;
 
 	/* at least one operand is null and we compare for equality or inequality ... */
 	if ((!v1 || !v2) && (how == I_EQ || how == I_NE)) {
@@ -2015,7 +2015,12 @@ ucv_compare(int how, uc_value_t *v1, uc_value_t *v2, int *deltap)
 		/* ... both operands are of the same, non-scalar type... */
 		if (t1 == t2 && !ucv_is_scalar(v1)) {
 			/* ... compare memory addrs */
-			delta = (intptr_t)v1 - (intptr_t)v2;
+			if ((uintptr_t)v1 == (uintptr_t)v2)
+				delta = 0;
+			else if ((uintptr_t)v1 < (uintptr_t)v2)
+				delta = -1;
+			else
+				delta = 1;
 		}
 
 		/* ... operands are of different type or at least one is scalar... */


### PR DESCRIPTION
-  types: don't rely on implicit type conversion in ucv_compare()
   - Don't implicitly convert `intptr_t` difference to `int8_t` but perform explicit comparisons
   - Don't implicitly convert `strcmp()` int result to `int8_t`
- fs: explicitly compare `isatty()` result
  - Reportedly, automatic conversion of the `isatty()` int result value to a bool does not work correctly on PPC. Explicitly compare the result value with `1` to infer the boolean result value.