### PR TITLE
rtnl: add IFLA_IF_NETNSID for operating in other namespaces

### DIFF
--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -724,9 +724,7 @@ static const uc_nl_nested_spec_t link_msg = {
 		{ IFLA_BROADCAST, "broadcast", DT_LLADDR, 0, NULL },
 		{ IFLA_TXQLEN, "txqlen", DT_U32, 0, NULL },
 		{ IFLA_MTU, "mtu", DT_U32, 0, NULL },
-		/* { IFLA_NETNS_PID, "netns", DT_U32, 0, NULL }, */
 		{ IFLA_CARRIER, "carrier", DT_BOOL, 0, NULL },
-		/* IFLA_VFINFO_LIST */
 		{ IFLA_MASTER, "master", DT_NETDEV, DF_ALLOW_NONE, NULL },
 		{ IFLA_IFALIAS, "ifalias", DT_STRING, 0, NULL },
 		{ IFLA_LINKMODE, "linkmode", DT_U8, 0, NULL },
@@ -743,6 +741,10 @@ static const uc_nl_nested_spec_t link_msg = {
 		{ IFLA_LINKINFO, "linkinfo", DT_LINKINFO, 0, NULL }, /* XXX: DF_NO_GET ? */
 		{ IFLA_EXT_MASK, "ext_mask", DT_U32, 0, NULL },
 		{ IFLA_STATS64, "stats64", DT_NESTED, DF_NO_SET, &link_attrs_stats64_rta },
+		/* TODO: IFLA_VFINFO_LIST */
+		/* TODO: the following two should be straightforward, just uncomment and test */
+		/* { IFLA_NET_NS_PID, "net_ns_pid", DT_S32, 0, NULL }, */
+		/* { IFLA_NET_NS_FD, "net_ns_fd", DT_S32, 0, NULL }, */
 	}
 };
 

--- a/lib/rtnl.c
+++ b/lib/rtnl.c
@@ -713,7 +713,7 @@ static const uc_nl_nested_spec_t link_attrs_stats64_rta = {
 
 static const uc_nl_nested_spec_t link_msg = {
 	.headsize = NLA_ALIGN(sizeof(struct ifinfomsg)),
-	.nattrs = 25,
+	.nattrs = 26,
 	.attrs = {
 		{ IFLA_UNSPEC, "family", DT_U8, 0, MEMBER(ifinfomsg, ifi_family) },
 		{ IFLA_UNSPEC, "type", DT_U16, 0, MEMBER(ifinfomsg, ifi_type) },
@@ -735,6 +735,7 @@ static const uc_nl_nested_spec_t link_msg = {
 		{ IFLA_NUM_RX_QUEUES, "num_rx_queues", DT_U32, 0, NULL },
 		{ IFLA_AF_SPEC, "af_spec", DT_AFSPEC, 0, NULL },
 		{ IFLA_LINK_NETNSID, "link_netnsid", DT_U32, 0, NULL },
+		{ IFLA_TARGET_NETNSID, "target_netnsid", DT_S32, 0, NULL },
 		{ IFLA_PROTO_DOWN, "proto_down", DT_BOOL, 0, NULL },
 		{ IFLA_GROUP, "group", DT_U32, 0, NULL },
 		{ IFLA_LINK, "link", DT_NETDEV, 0, NULL },


### PR DESCRIPTION
IFLA_IF_NETNSID allows RTM_GETLINK et. al. to operate in other network namespaces. For example I use it to check if a given interface exists in a given namespace.

```js
  let reply = rtnl.request(rtnl.const.RTM_GETLINK, rtnl.const.NLM_F_REQUEST, {
    "ifname": ifname,
    "if_netnsid": nsid,
  });
```

The nsid is set with `ip netns set <nsname> <nsid>` and obtained with `ip -j netns list-id`.