### PR TITLE
vm: Handle return value of write()

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3152,13 +3152,16 @@ void
 uc_vm_signal_raise(uc_vm_t *vm, int signo)
 {
 	uint8_t signum = signo;
+	ssize_t size;
 
 	if (signo <= 0 || signo >= UC_SYSTEM_SIGNAL_COUNT)
 		return;
 
 	vm->signal.raised[signo / 64] |= (1ull << (signo % 64));
 
-	write(vm->signal.sigpipe[1], &signum, sizeof(signum));
+	size = write(vm->signal.sigpipe[1], &signum, sizeof(signum));
+	if (size != sizeof(signum))
+		fprintf(stderr, "writing to signal pipe failed\n");
 }
 
 int


### PR DESCRIPTION
Fix a compile error when compiling against glibc:
vm.c: In function 'uc_vm_signal_raise':
vm.c:3161:9: error: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Werror=unused-result]
 3161 |         write(vm->signal.sigpipe[1], &signum, sizeof(signum));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~