### PR TITLE
syntax: don't treat `as` and `from` as reserved keywords

### DIFF
--- a/include/ucode/lexer.h
+++ b/include/ucode/lexer.h
@@ -119,8 +119,6 @@ typedef enum {
 	TK_TEMPLATE,
 	TK_IMPORT,
 	TK_EXPORT,
-	TK_FROM,
-	TK_AS,
 
 	TK_EOF,
 	TK_ERROR

--- a/lexer.c
+++ b/lexer.c
@@ -68,13 +68,11 @@ static const struct keyword reserved_words[] = {
 	{ TK_THIS,		"this",  4 },
 	{ TK_NULL,		"null",  4 },
 	{ TK_CASE,		"case",  4 },
-	{ TK_FROM,		"from",  4 },
 	{ TK_TRY,		"try",   3 },
 	{ TK_FOR,		"for",   3 },
 	{ TK_LOCAL,		"let",   3 },
 	{ TK_IF,		"if",    2 },
 	{ TK_IN,		"in",    2 },
-	{ TK_AS,		"as",    2 },
 };
 
 

--- a/tests/custom/99_bugs/44_compiler_as_from_identifier
+++ b/tests/custom/99_bugs/44_compiler_as_from_identifier
@@ -1,0 +1,44 @@
+Ensure that `as` and `from` are valid identifiers while their special
+meaning in import statements is retained.
+
+-- Testcase --
+import { foo as bar } from 'mod';
+import * as mod from 'mod';
+
+function fn(as, from) {
+	return as + from;
+}
+
+as = 1;
+from = true;
+
+printf("%.J\n", [
+	bar,
+	mod,
+	fn(1, 2),
+	as,
+	from
+]);
+-- End --
+
+-- File mod.uc --
+export let foo = false;
+export default 'test';
+-- End --
+
+-- Args --
+-R -L files/
+-- End --
+
+-- Expect stdout --
+[
+	false,
+	{
+		"foo": false,
+		"default": "test"
+	},
+	3,
+	1,
+	true
+]
+-- End --


### PR DESCRIPTION
ECMAScript allows using `as` and `from` as identifiers so follow suit and don't treat them specially while parsing. Extend the compiler logic instead to check for TK_LABEL tokens with the expected value to properly parse import and export statements.