### PR TITLE
vm: rework object iteration

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -207,6 +207,16 @@ typedef struct {
 uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
 
 
+/* Object iteration */
+
+extern uc_list_t uc_object_iterators;
+
+typedef struct {
+	uc_list_t list;
+	struct lh_entry *pos;
+} uc_object_iterator_t;
+
+
 /* Program structure definitions */
 
 uc_declare_vector(uc_sources_t, uc_source_t *);

--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -79,6 +79,32 @@
 } while(0)
 
 
+/* linked lists */
+
+typedef struct uc_list {
+	struct uc_list *prev;
+	struct uc_list *next;
+} uc_list_t;
+
+static inline void uc_list_insert(uc_list_t *list, uc_list_t *item)
+{
+	list->next->prev = item;
+	item->next = list->next;
+	item->prev = list;
+	list->next = item;
+}
+
+static inline void uc_list_remove(uc_list_t *item)
+{
+	item->next->prev = item->prev;
+	item->prev->next = item->next;
+	item->prev = item->next = item;
+}
+
+#define uc_list_foreach(item, list) \
+	for (uc_list_t *item = (list)->next; item != (list); item = item->next)
+
+
 /* "failsafe" utility functions */
 
 static inline void *xcalloc(size_t size, size_t nmemb) {

--- a/tests/custom/02_runtime/08_object_iteration
+++ b/tests/custom/02_runtime/08_object_iteration
@@ -1,0 +1,51 @@
+Testing object iteration behavior.
+
+
+1. Testing that deleting properties during iteration is safe.
+
+-- Expect stdout --
+a
+w
+z
+-- End --
+
+-- Testcase --
+{%
+	o1 = { a: 1, b: 2, c: 3 };
+
+	for (k in o1) {
+		delete o1.a;
+		delete o1.b;
+		delete o1.c;
+		print(k, "\n");
+	}
+
+	o2 = { w: 1, x: 2, y: 3, z: 4 };
+
+	for (k in o2) {
+		delete o2.x;
+		delete o2.y;
+		print(k, "\n");
+	}
+%}
+-- End --
+
+
+2. Test that reordering object properties during iteration is safe.
+
+-- Expect stdout --
+c
+b
+c
+-- End --
+
+-- Testcase --
+{%
+	o = { c: 1, b: 2, a: 3 };
+
+	for (k in o) {
+		sort(o);
+		print(k, "\n");
+	}
+%}
+-- End --

--- a/types.c
+++ b/types.c
@@ -29,6 +29,11 @@
 #include "ucode/vm.h"
 #include "ucode/program.h"
 
+uc_list_t uc_object_iterators = {
+	.prev = &uc_object_iterators,
+	.next = &uc_object_iterators
+};
+
 static char *uc_default_search_path[] = { LIB_SEARCH_PATH };
 
 uc_parse_config_t uc_default_parse_config = {
@@ -888,6 +893,13 @@ ucv_array_length(uc_value_t *uv)
 static void
 ucv_free_object_entry(struct lh_entry *entry)
 {
+	uc_list_foreach(item, &uc_object_iterators) {
+		uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
+
+		if (iter->pos == entry)
+			iter->pos = entry->next;
+	}
+
 	free(lh_entry_k(entry));
 	ucv_put(lh_entry_v(entry));
 }


### PR DESCRIPTION
Ensure that deleting object keys during iteration is safe by keeping a global chain of per-object iterators which are advanced to the next key when the entry that is about to be iterated is deleted.