### PR TITLE
ubus: automatically clear error information

### DIFF
--- a/lib/uci.c
+++ b/lib/uci.c
@@ -53,6 +53,7 @@
 
 #include "ucode/module.h"
 
+#define ok_return(expr) do { last_error = 0; return (expr); } while(0)
 #define err_return(err) do { last_error = err; return NULL; } while(0)
 
 static int last_error = 0;
@@ -178,7 +179,7 @@ uc_uci_cursor(uc_vm_t *vm, size_t nargs)
 			err_return(rv);
 	}
 
-	return uc_resource_new(cursor_type, c);
+	ok_return(uc_resource_new(cursor_type, c));
 }
 
 
@@ -366,7 +367,7 @@ uc_uci_load(uc_vm_t *vm, size_t nargs)
 	if (uci_load(*c, s, NULL))
 		err_return((*c)->err);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 /**
@@ -406,11 +407,11 @@ uc_uci_unload(uc_vm_t *vm, size_t nargs)
 		if (!strcmp(e->name, ucv_string_get(conf))) {
 			uci_unload(*c, uci_to_package(e));
 
-			return ucv_boolean_new(true);
+			ok_return(ucv_boolean_new(true));
 		}
 	}
 
-	return ucv_boolean_new(false);
+	ok_return(ucv_boolean_new(false));
 }
 
 static int
@@ -548,26 +549,26 @@ uc_uci_get_any(uc_vm_t *vm, size_t nargs, bool all)
 			if (!ptr.s)
 				err_return(UCI_ERR_NOTFOUND);
 
-			return section_to_uval(vm, ptr.s, -1);
+			ok_return(section_to_uval(vm, ptr.s, -1));
 		}
 
 		if (!ptr.p)
 			err_return(UCI_ERR_NOTFOUND);
 
-		return package_to_uval(vm, ptr.p);
+		ok_return(package_to_uval(vm, ptr.p));
 	}
 
 	if (ptr.option) {
 		if (!ptr.o)
 			err_return(UCI_ERR_NOTFOUND);
 
-		return option_to_uval(vm, ptr.o);
+		ok_return(option_to_uval(vm, ptr.o));
 	}
 
 	if (!ptr.s)
 		err_return(UCI_ERR_NOTFOUND);
 
-	return ucv_string_new(ptr.s->type);
+	ok_return(ucv_string_new(ptr.s->type));
 }
 
 /**
@@ -739,7 +740,7 @@ uc_uci_get_first(uc_vm_t *vm, size_t nargs)
 			continue;
 
 		if (!opt)
-			return ucv_string_new(sc->e.name);
+			ok_return(ucv_string_new(sc->e.name));
 
 		ptr.package = ucv_string_get(conf);
 		ptr.section = sc->e.name;
@@ -755,7 +756,7 @@ uc_uci_get_first(uc_vm_t *vm, size_t nargs)
 		if (!(ptr.flags & UCI_LOOKUP_COMPLETE))
 			err_return(UCI_ERR_NOTFOUND);
 
-		return option_to_uval(vm, ptr.o);
+		ok_return(option_to_uval(vm, ptr.o));
 	}
 
 	err_return(UCI_ERR_NOTFOUND);
@@ -1040,7 +1041,7 @@ uc_uci_set(uc_vm_t *vm, size_t nargs)
 			err_return(rv);
 	}
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 /**
@@ -1119,7 +1120,7 @@ uc_uci_delete(uc_vm_t *vm, size_t nargs)
 	if (rv != UCI_OK)
 		err_return(rv);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 /**
@@ -1228,7 +1229,7 @@ uc_uci_rename(uc_vm_t *vm, size_t nargs)
 	if (rv != UCI_OK)
 		err_return(rv);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 /**
@@ -1336,7 +1337,7 @@ uc_uci_reorder(uc_vm_t *vm, size_t nargs)
 	if (rv != UCI_OK)
 		err_return(rv);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static int
@@ -1406,7 +1407,7 @@ uc_uci_pkg_command(uc_vm_t *vm, size_t nargs, enum pkg_cmd cmd)
 	if (res != UCI_OK)
 		err_return(res);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 /**
@@ -1687,7 +1688,7 @@ uc_uci_changes(uc_vm_t *vm, size_t nargs)
 
 	free(configs);
 
-	return res;
+	ok_return(res);
 }
 
 /**
@@ -1789,7 +1790,7 @@ uc_uci_foreach(uc_vm_t *vm, size_t nargs)
 			break;
 	}
 
-	return ucv_boolean_new(ret);
+	ok_return(ucv_boolean_new(ret));
 }
 
 /**
@@ -1832,7 +1833,7 @@ uc_uci_configs(uc_vm_t *vm, size_t nargs)
 
 	free(configs);
 
-	return a;
+	ok_return(a);
 }
 
 

--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -25,6 +25,7 @@
 #include "ucode/module.h"
 #include "ucode/platform.h"
 
+#define ok_return(expr) do { last_error = 0; return (expr); } while(0)
 #define err_return(err) do { last_error = err; return NULL; } while(0)
 
 static uc_resource_type_t *timer_type, *handle_type, *process_type, *task_type, *pipe_type;
@@ -113,7 +114,7 @@ uc_uloop_init(uc_vm_t *vm, size_t nargs)
 	if (rv == -1)
 		err_return(errno);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static uc_value_t *
@@ -130,13 +131,13 @@ uc_uloop_run(uc_vm_t *vm, size_t nargs)
 
 	rv = uloop_run_timeout(t);
 
-	return ucv_int64_new(rv);
+	ok_return(ucv_int64_new(rv));
 }
 
 static uc_value_t *
 uc_uloop_cancelling(uc_vm_t *vm, size_t nargs)
 {
-	return ucv_boolean_new(uloop_cancelling());
+	ok_return(ucv_boolean_new(uloop_cancelling()));
 }
 
 static uc_value_t *
@@ -149,7 +150,7 @@ uc_uloop_running(uc_vm_t *vm, size_t nargs)
 	active = uloop_cancelling();
 	uloop_cancelled = prev;
 
-	return ucv_boolean_new(active);
+	ok_return(ucv_boolean_new(active));
 }
 
 static uc_value_t *
@@ -157,7 +158,7 @@ uc_uloop_end(uc_vm_t *vm, size_t nargs)
 {
 	uloop_end();
 
-	return NULL;
+	ok_return(NULL);
 }
 
 static uc_value_t *
@@ -165,7 +166,7 @@ uc_uloop_done(uc_vm_t *vm, size_t nargs)
 {
 	uloop_done();
 
-	return NULL;
+	ok_return(NULL);
 }
 
 
@@ -202,7 +203,7 @@ uc_uloop_timer_set(uc_vm_t *vm, size_t nargs)
 
 	rv = uloop_timeout_set(&(*timer)->timeout, t);
 
-	return ucv_boolean_new(rv == 0);
+	ok_return(ucv_boolean_new(rv == 0));
 }
 
 static uc_value_t *
@@ -220,7 +221,7 @@ uc_uloop_timer_remaining(uc_vm_t *vm, size_t nargs)
 	rem = (int64_t)uloop_timeout_remaining(&(*timer)->timeout);
 #endif
 
-	return ucv_int64_new(rem);
+	ok_return(ucv_int64_new(rem));
 }
 
 static uc_value_t *
@@ -236,7 +237,7 @@ uc_uloop_timer_cancel(uc_vm_t *vm, size_t nargs)
 
 	uc_uloop_timeout_clear(timer);
 
-	return ucv_boolean_new(rv == 0);
+	ok_return(ucv_boolean_new(rv == 0));
 }
 
 static void
@@ -276,7 +277,7 @@ uc_uloop_timer(uc_vm_t *vm, size_t nargs)
 
 	timer->registry_index = uc_uloop_reg_add(res, callback);
 
-	return res;
+	ok_return(res);
 }
 
 
@@ -305,7 +306,7 @@ uc_uloop_handle_fileno(uc_vm_t *vm, size_t nargs)
 	if (!handle || !*handle)
 		err_return(EINVAL);
 
-	return ucv_int64_new((*handle)->fd.fd);
+	ok_return(ucv_int64_new((*handle)->fd.fd));
 }
 
 static uc_value_t *
@@ -316,7 +317,7 @@ uc_uloop_handle_handle(uc_vm_t *vm, size_t nargs)
 	if (!handle || !*handle)
 		err_return(EINVAL);
 
-	return ucv_get((*handle)->handle);
+	ok_return(ucv_get((*handle)->handle));
 }
 
 static uc_value_t *
@@ -335,7 +336,7 @@ uc_uloop_handle_delete(uc_vm_t *vm, size_t nargs)
 	if (rv != 0)
 		err_return(errno);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static void
@@ -435,7 +436,7 @@ uc_uloop_handle(uc_vm_t *vm, size_t nargs)
 
 	handle->registry_index = uc_uloop_reg_add(res, callback);
 
-	return res;
+	ok_return(res);
 }
 
 
@@ -461,7 +462,7 @@ uc_uloop_process_pid(uc_vm_t *vm, size_t nargs)
 	if (!process || !*process)
 		err_return(EINVAL);
 
-	return ucv_int64_new((*process)->process.pid);
+	ok_return(ucv_int64_new((*process)->process.pid));
 }
 
 static uc_value_t *
@@ -480,7 +481,7 @@ uc_uloop_process_delete(uc_vm_t *vm, size_t nargs)
 	if (rv != 0)
 		err_return(EINVAL);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static void
@@ -562,7 +563,7 @@ uc_uloop_process(uc_vm_t *vm, size_t nargs)
 
 	process->registry_index = uc_uloop_reg_add(res, callback);
 
-	return res;
+	ok_return(res);
 }
 
 
@@ -645,7 +646,7 @@ uc_uloop_pipe_send_common(uc_vm_t *vm, uc_value_t *msg, int fd)
 	if (!rv)
 		err_return(errno);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static uc_value_t *
@@ -660,7 +661,7 @@ uc_uloop_pipe_send(uc_vm_t *vm, size_t nargs)
 	if (!(*pipe)->has_receiver)
 		err_return(EPIPE);
 
-	return uc_uloop_pipe_send_common(vm, msg, (*pipe)->output);
+	ok_return(uc_uloop_pipe_send_common(vm, msg, (*pipe)->output));
 }
 
 static bool
@@ -773,7 +774,7 @@ uc_uloop_pipe_sending(uc_vm_t *vm, size_t nargs)
 	if (!pipe || !*pipe)
 		err_return(EINVAL);
 
-	return ucv_boolean_new((*pipe)->has_sender);
+	ok_return(ucv_boolean_new((*pipe)->has_sender));
 }
 
 static uc_value_t *
@@ -784,7 +785,7 @@ uc_uloop_pipe_receiving(uc_vm_t *vm, size_t nargs)
 	if (!pipe || !*pipe)
 		err_return(EINVAL);
 
-	return ucv_boolean_new((*pipe)->has_receiver);
+	ok_return(ucv_boolean_new((*pipe)->has_receiver));
 }
 
 
@@ -840,7 +841,7 @@ uc_uloop_task_pid(uc_vm_t *vm, size_t nargs)
 	if ((*task)->finished)
 		err_return(ESRCH);
 
-	return ucv_int64_new((*task)->process.pid);
+	ok_return(ucv_int64_new((*task)->process.pid));
 }
 
 static uc_value_t *
@@ -860,7 +861,7 @@ uc_uloop_task_kill(uc_vm_t *vm, size_t nargs)
 	if (rv == -1)
 		err_return(errno);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static uc_value_t *
@@ -871,7 +872,7 @@ uc_uloop_task_finished(uc_vm_t *vm, size_t nargs)
 	if (!task || !*task)
 		err_return(EINVAL);
 
-	return ucv_boolean_new((*task)->finished);
+	ok_return(ucv_boolean_new((*task)->finished));
 }
 
 static void
@@ -1047,7 +1048,7 @@ uc_uloop_task(uc_vm_t *vm, size_t nargs)
 
 	task->registry_index = uc_uloop_reg_add(res, cbs);
 
-	return res;
+	ok_return(res);
 }
 
 
@@ -1085,7 +1086,7 @@ uc_uloop_interval_set(uc_vm_t *vm, size_t nargs)
 
 	rv = uloop_interval_set(&(*interval)->interval, t);
 
-	return ucv_boolean_new(rv == 0);
+	ok_return(ucv_boolean_new(rv == 0));
 }
 
 static uc_value_t *
@@ -1096,7 +1097,7 @@ uc_uloop_interval_remaining(uc_vm_t *vm, size_t nargs)
 	if (!interval || !*interval)
 		err_return(EINVAL);
 
-	return ucv_int64_new(uloop_interval_remaining(&(*interval)->interval));
+	ok_return(ucv_int64_new(uloop_interval_remaining(&(*interval)->interval)));
 }
 
 static uc_value_t *
@@ -1107,7 +1108,7 @@ uc_uloop_interval_expirations(uc_vm_t *vm, size_t nargs)
 	if (!interval || !*interval)
 		err_return(EINVAL);
 
-	return ucv_int64_new((*interval)->interval.expirations);
+	ok_return(ucv_int64_new((*interval)->interval.expirations));
 }
 
 static uc_value_t *
@@ -1123,7 +1124,7 @@ uc_uloop_interval_cancel(uc_vm_t *vm, size_t nargs)
 
 	uc_uloop_interval_clear(interval);
 
-	return ucv_boolean_new(rv == 0);
+	ok_return(ucv_boolean_new(rv == 0));
 }
 
 static void
@@ -1163,7 +1164,7 @@ uc_uloop_interval(uc_vm_t *vm, size_t nargs)
 
 	interval->registry_index = uc_uloop_reg_add(res, callback);
 
-	return res;
+	ok_return(res);
 }
 #endif
 
@@ -1191,7 +1192,7 @@ uc_uloop_signal_signo(uc_vm_t *vm, size_t nargs)
 	if (!signal || !*signal)
 		err_return(EINVAL);
 
-	return ucv_int64_new((*signal)->signal.signo);
+	ok_return(ucv_int64_new((*signal)->signal.signo));
 }
 
 static uc_value_t *
@@ -1210,7 +1211,7 @@ uc_uloop_signal_delete(uc_vm_t *vm, size_t nargs)
 	if (rv != 0)
 		err_return(EINVAL);
 
-	return ucv_boolean_new(true);
+	ok_return(ucv_boolean_new(true));
 }
 
 static void
@@ -1273,7 +1274,7 @@ uc_uloop_signal(uc_vm_t *vm, size_t nargs)
 
 	signal->registry_index = uc_uloop_reg_add(res, callback);
 
-	return res;
+	ok_return(res);
 }
 #endif
 


### PR DESCRIPTION
Make all functions clear the last error information on success in order to ensure that `error()` never reports stale information.