### PR TITLE
make `"" in [0]` false again

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2074,7 +2074,7 @@ uc_vm_insn_in(uc_vm_t *vm, uc_vm_insn_t insn)
 		     arridx < arrlen; arridx++) {
 			item = ucv_array_get(r2, arridx);
 
-			if (ucv_compare(I_EQ, r1, item, NULL)) {
+			if ((ucv_is_scalar(r1) && ucv_is_scalar(item) && ucv_is_equal(r1, item)) || (r1 == item)) {
 				found = true;
 				break;
 			}


### PR DESCRIPTION
Before this change: `0 in [""]` is true

After this change: `0 in [""]` is false

Hitherto, the `in` operator has used non-strict equality when testing for array membership. Since the non-strict equality `0 == ""` is true, this means that `0 in [""]` and `"" in [0]` are surprisingly true. The present pull request switches to strict equality, guided by how it's done in [`uc_vm_insn_equality`](https://github.com/jow-/ucode/blob/ba3855ae3775197f3594fc2615cac539075bd2fb/vm.c#L2114-L2117).

Honestly, I think that strict equality (as in `===`) makes sense in almost all situations and should be what's used under the hood everywhere. I wouldn't mind abolishing non-strict equality altogether.