### PR TITLE
fs: add ioctl() file method

### DIFF
--- a/tests/custom/03_stdlib/40_proto
+++ b/tests/custom/03_stdlib/40_proto
@@ -38,6 +38,7 @@ When invoked with two arguments, returns the given value.
 Hello, World!
 [
 	{
+		"ioctl": "function ioctl(...) { [native code] }",
 		"lock": "function lock(...) { [native code] }",
 		"truncate": "function truncate(...) { [native code] }",
 		"isatty": "function isatty(...) { [native code] }",


### PR DESCRIPTION
This adds an ioctl method to file, allowing to perform arbitrary ioctl operations on the opened file handle. The caller is responsible for providing correct input to the ioctl operation and is also responsible for packing/unpacking the payload accordingly. 

I'd like to collect some feedback on this, and discuss my implementation attempt. This is the first time I'm dealing with ucode, so probably I missed something here. 
My intention for this is to use it in a written-in-ucode daemon for OpenWrt, but it may be quite useful for other applications too. I hope there aren't any critical objections against having ioctl() support in ucode. 
So far, I only tested a simple ioctl read operation, which works fine. If my proposed changes here are likely to be included, I will test the other operations too to be sure everything works.

One point I'm not sure about and I'd like to discuss: is it necessary or wise to check if the file is a special file instead of a normal file, or do we just let the real ioctl fail in such a case?
