### PR TITLE
compiler: properly treat property names after spread expressions

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -2060,6 +2060,7 @@ uc_compiler_compile_object(uc_compiler_t *compiler)
 			/* emit merge operation */
 			uc_compiler_emit_insn(compiler, 0, I_MOBJ);
 
+			compiler->parser->lex.no_keyword = true;
 			continue;
 		}
 

--- a/tests/custom/99_bugs/47_compiler_no_prop_kw_after_spread
+++ b/tests/custom/99_bugs/47_compiler_no_prop_kw_after_spread
@@ -1,0 +1,17 @@
+Ensure that unquoted property names following spread expressions in object
+declaration literals are not treated as keywords.
+
+-- Testcase --
+{%
+printf("%.J\n", {
+	...{},
+	for: true
+});
+%}
+-- End --
+
+-- Expect stdout --
+{
+	"for": true
+}
+-- End --


### PR DESCRIPTION
Ensure that unquoted property names following spread expressions in object declaration literals are not treated as keywords.

Prior to this fix, an expression such as `{ ...someobj, default: 1 }` would result in a compile time syntax error.