### PR TITLE
header util.h changed to be accepted by c++ compiler

### DIFF
--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -55,7 +55,7 @@
 #define uc_vector_grow(vec) \
 	do { \
 		if (((vec)->count % UC_VECTOR_CHUNK_SIZE) == 0) { \
-			(vec)->entries = xrealloc((vec)->entries, sizeof((vec)->entries[0]) * ((vec)->count + UC_VECTOR_CHUNK_SIZE)); \
+			*(void **)&(vec)->entries = xrealloc((vec)->entries, sizeof((vec)->entries[0]) * ((vec)->count + UC_VECTOR_CHUNK_SIZE)); \
 			memset(&(vec)->entries[(vec)->count], 0, sizeof((vec)->entries[0]) * UC_VECTOR_CHUNK_SIZE); \
 		} \
 	} while(0)


### PR DESCRIPTION
It's hard to embed ucode in a c++ object, because it's headers are not accepted by a c++ compiler. There are two problems,
```
ucode/include/ucode/types.h:126:14: error: ISO C++ forbids flexible array member 'name' [-Wpedantic]
         char name[];
```
and 
```
ucode/include/ucode/util.h:58:48: error: invalid conversion from 'void*' to 'char**' [-fpermissive]
       vec->entries = xrealloc((vec)->entries, sizeof((vec)->entries[0]) * ((vec)->count + UC_VECTOR_CHUNK_SIZE));
```
The first one can be solved by a wrapper header file using #pragma system_header:
```c++
#ifdef __cplusplus
extern "C"{
#endif
#pragma GCC system_header
#include <ucode/types.h>
#ifdef __cplusplus
} // extern "C"
#endif
```
the second one is solved by this PR