### PR TITLE
lib: Removed global variables from module fs for thread safety

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -422,6 +422,17 @@ uc_value_t *ucv_resource_new(uc_resource_type_t *, void *);
 void *ucv_resource_data(uc_value_t *uv, const char *);
 void **ucv_resource_dataptr(uc_value_t *, const char *);
 
+static inline uc_value_t *
+ucv_resource_create(uc_vm_t *vm, const char *typename, void *value)
+{
+    uc_resource_type_t *t = NULL;
+
+    if (typename && (t = ucv_resource_type_lookup(vm, typename)) == NULL)
+        return NULL;
+
+    return ucv_resource_new(t, value);
+}
+
 uc_value_t *ucv_regexp_new(const char *, bool, bool, bool, char **);
 
 uc_value_t *ucv_upvalref_new(size_t);


### PR DESCRIPTION
The resource objects are created by resource name, and the last_error is stored in a registry entry.