### PR TITLE
Remove global variable sort_ctx in libucode for thread safety.

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -206,10 +206,14 @@ typedef struct {
 
 uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);
 
+/* Thread local data */
+struct uc_threadlocal
+{
+	/* Object iteration */
+	uc_list_t object_iterators;	
+}; 
 
-/* Object iteration */
-
-extern uc_list_t uc_object_iterators;
+extern __thread struct uc_threadlocal *uc_threadlocal_data;
 
 typedef struct {
 	uc_list_t list;

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -380,7 +380,7 @@ uc_value_t *ucv_array_pop(uc_value_t *);
 uc_value_t *ucv_array_push(uc_value_t *, uc_value_t *);
 uc_value_t *ucv_array_shift(uc_value_t *);
 uc_value_t *ucv_array_unshift(uc_value_t *, uc_value_t *);
-void ucv_array_sort(uc_value_t *, int (*)(const void *, const void *));
+void ucv_array_sort(uc_value_t *, int (*)(uc_value_t * const *, uc_value_t * const *,void *),void *);
 bool ucv_array_delete(uc_value_t *, size_t, size_t);
 bool ucv_array_set(uc_value_t *, size_t, uc_value_t *);
 size_t ucv_array_length(uc_value_t *);
@@ -388,7 +388,7 @@ size_t ucv_array_length(uc_value_t *);
 uc_value_t *ucv_object_new(uc_vm_t *);
 uc_value_t *ucv_object_get(uc_value_t *, const char *, bool *);
 bool ucv_object_add(uc_value_t *, const char *, uc_value_t *);
-void ucv_object_sort(uc_value_t *, int (*)(const void *, const void *));
+void ucv_object_sort(uc_value_t *, int (*)(struct lh_entry * const *, struct lh_entry * const *,void *), void *);
 bool ucv_object_delete(uc_value_t *, const char *);
 size_t ucv_object_length(uc_value_t *);
 

--- a/lib/fs.c
+++ b/lib/fs.c
@@ -2232,11 +2232,8 @@ uc_fs_basename(uc_vm_t *vm, size_t nargs)
 }
 
 static int
-uc_fs_lsdir_sort_fn(const void *k1, const void *k2)
+uc_fs_lsdir_sort_fn(uc_value_t * const *v1, uc_value_t * const *v2,void *)
 {
-	uc_value_t * const *v1 = k1;
-	uc_value_t * const *v2 = k2;
-
 	return strcmp(ucv_string_get(*v1), ucv_string_get(*v2));
 }
 
@@ -2310,7 +2307,7 @@ uc_fs_lsdir(uc_vm_t *vm, size_t nargs)
 
 	closedir(d);
 
-	ucv_array_sort(res, uc_fs_lsdir_sort_fn);
+	ucv_array_sort(res, uc_fs_lsdir_sort_fn,0);
 
 	return res;
 }

--- a/types.c
+++ b/types.c
@@ -791,14 +791,16 @@ ucv_array_unshift(uc_value_t *uv, uc_value_t *item)
 }
 
 void
-ucv_array_sort(uc_value_t *uv, int (*cmp)(const void *, const void *))
+ucv_array_sort(uc_value_t *uv, int (*cmp)(uc_value_t * const *,uc_value_t * const *,void *),void *ctx)
 {
 	uc_array_t *array = (uc_array_t *)uv;
 
 	if (ucv_type(uv) != UC_ARRAY || array->count <= 1)
 		return;
 
-	qsort(array->entries, array->count, sizeof(array->entries[0]), cmp);
+	qsort_r(array->entries, array->count, sizeof(array->entries[0]), 
+		(int (*)(const void *,const void *,void *))cmp, 
+		ctx);
 }
 
 bool
@@ -968,7 +970,8 @@ ucv_object_add(uc_value_t *uv, const char *key, uc_value_t *val)
 }
 
 void
-ucv_object_sort(uc_value_t *uv, int (*cmp)(const void *, const void *))
+ucv_object_sort(uc_value_t *uv, 
+	int (*cmp)(struct lh_entry * const *, struct lh_entry * const *, void *), void *ctx )
 {
 	uc_object_t *object = (uc_object_t *)uv;
 	struct lh_table *t;
@@ -989,7 +992,9 @@ ucv_object_sort(uc_value_t *uv, int (*cmp)(const void *, const void *))
 	if (!keys.entries)
 		return;
 
-	qsort(keys.entries, keys.count, sizeof(keys.entries[0]), cmp);
+	qsort_r(keys.entries, keys.count, sizeof(keys.entries[0]), 
+		(int (*)(const void *,const void *,void *))cmp, 
+		ctx);
 
 	for (i = 0; i < keys.count; i++) {
 		e = keys.entries[i];

--- a/types.c
+++ b/types.c
@@ -29,10 +29,7 @@
 #include "ucode/vm.h"
 #include "ucode/program.h"
 
-uc_list_t uc_object_iterators = {
-	.prev = &uc_object_iterators,
-	.next = &uc_object_iterators
-};
+__thread struct uc_threadlocal *uc_threadlocal_data;
 
 static char *uc_default_search_path[] = { LIB_SEARCH_PATH };
 
@@ -878,7 +875,7 @@ ucv_array_length(uc_value_t *uv)
 static void
 ucv_free_object_entry(struct lh_entry *entry)
 {
-	uc_list_foreach(item, &uc_object_iterators) {
+	uc_list_foreach(item, &uc_threadlocal_data->object_iterators) {
 		uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
 
 		if (iter->u.pos == entry)
@@ -935,7 +932,7 @@ ucv_object_add(uc_value_t *uv, const char *key, uc_value_t *val)
 
 		/* insert will rehash table, backup affected iterator states */
 		if (rehash) {
-			uc_list_foreach(item, &uc_object_iterators) {
+			uc_list_foreach(item, &uc_threadlocal_data->object_iterators) {
 				uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
 
 				if (iter->table != object->table)
@@ -959,7 +956,7 @@ ucv_object_add(uc_value_t *uv, const char *key, uc_value_t *val)
 
 		/* restore affected iterator state pointer after rehash */
 		if (rehash) {
-			uc_list_foreach(item, &uc_object_iterators) {
+			uc_list_foreach(item, &uc_threadlocal_data->object_iterators) {
 				uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
 
 				if (iter->table != object->table)


### PR DESCRIPTION
The global variable is exchange by a local one by use of qsort_r() instead of qsort(). 

Further I changed the declarations of ucv_array_sort() and ucv_object_sort() to deal with the extra void pointer. Further I changed the declaration of the compare function to use the final argument types. I think it's cleaner to cast the function once, deep in the library, than have to cast the arguments of the function everywhere.
