### PR TITLE
vallist: more thoroughly check for trailing garbage after numeric string

### DIFF
--- a/tests/custom/99_bugs/49_trailing_garbage_string_as_number
+++ b/tests/custom/99_bugs/49_trailing_garbage_string_as_number
@@ -1,0 +1,23 @@
+Ensure that numeric strings followed by non-whitespace are treated as NaN.
+
+-- Testcase --
+{%
+printf("%.J\n", [
+	"1" == 1,
+	" 1" == 1,
+	"1 " == 1,
+	"1a" == 1,
+	"1 a" == 1
+]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	true,
+	true,
+	true,
+	false,
+	false
+]
+-- End --

--- a/vallist.c
+++ b/vallist.c
@@ -106,7 +106,10 @@ uc_number_parse_common(const char *buf, bool octal, char **end)
 	if (base >= 10 && (**end == '.' || (**end|32) == 'e')) {
 		d = strtod(p, end);
 
-		if (!isspace(**end) && **end != 0)
+		while (isspace(**end))
+			(*end)++;
+
+		if (**end != 0)
 			return NULL;
 
 		if (neg)
@@ -115,7 +118,10 @@ uc_number_parse_common(const char *buf, bool octal, char **end)
 		return ucv_double_new(d);
 	}
 
-	if (!isspace(**end) && **end != 0)
+	while (isspace(**end))
+		(*end)++;
+
+	if (**end != 0)
 		return NULL;
 
 	if (neg) {


### PR DESCRIPTION
When converting numeric strings into numbers, ensure that only optional trailing whitespace follows and no other characters.

Fixes: #231