### PR TITLE
main: fix crash on printing -p output

### DIFF
--- a/main.c
+++ b/main.c
@@ -155,8 +155,6 @@ compile(uc_vm_t *vm, uc_source_t *src, FILE *precompile, bool strip, char *inter
 				fwrite(pb->buf, pb->bpos, 1, stdout);
 				printbuf_free(pb);
 			}
-
-			ucv_put(res);
 		}
 
 		rc = 0;


### PR DESCRIPTION
Delete a duplicate ucv_put() line that can lead to a double-free bug.

Reproduced by running:
ucode -l nl80211 -p 'sprintf("%.J\n",
    nl80211.request(nl80211.const.NL80211_CMD_GET_WIPHY,
                    nl80211.const.NLM_F_DUMP,
		    { wiphy: 0, split_wiphy_dump: true }))'

Fixes: 0a7ff4715cb8 ("main: pretty-print `-p` output by default")