### PR TITLE
struct: fix memory leak in buffer.pull()

### DIFF
--- a/lib/struct.c
+++ b/lib/struct.c
@@ -2514,7 +2514,10 @@ grow_buffer(uc_vm_t *vm, void **buf, size_t *bufsz, size_t length)
 			return false;
 		}
 
-		memset(tmp + overhead + old_size - 1, 0, new_size - old_size + 1);
+		if (*buf)
+			memset(tmp + overhead + old_size - 1, 0, new_size - old_size + 1);
+		else
+			memset(tmp, 0, new_size + overhead);
 
 		*buf = tmp;
 		*bufsz = new_size;
@@ -3655,7 +3658,7 @@ uc_fmtbuf_pull(uc_vm_t *vm, size_t nargs)
 	buffer->position = 0;
 	buffer->length = 0;
 
-	return ucv_get(&us->header);
+	return &us->header;
 }
 
 


### PR DESCRIPTION
Do not increase the refcount when returning the pulled buffer contents as string since the returned value already is the sole reference. Without this change, pulled buffer contents will be leaked whenever the `pull()` function is used.

Also ensure that the buffer memory is completely zero initialized when it is allocated from scratch, the existing logic only cleared the trailing data area on reallocations but never the head on fresh allocations.