### PR TITLE
debian/control: Build-Depend on cmake

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,9 @@
 Source: ucode
 Maintainer: Paul Spooren <mail@aparcar.org>
-Section: misc
+Section: interpreters
 Priority: optional
 Standards-Version: 0.0.20220322-1
-Build-Depends: debhelper-compat (= 12), libjson-c-dev
+Build-Depends: debhelper-compat (= 12), cmake, pkg-config, libjson-c-dev
 
 Package: ucode
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,13 @@ Source: ucode
 Maintainer: Paul Spooren <mail@aparcar.org>
 Section: interpreters
 Priority: optional
-Standards-Version: 0.0.20220322-1
+Standards-Version: 4.5.0
+Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 12), cmake, pkg-config, libjson-c-dev
+Homepage: https://github.com/jow-/ucode
+Vcs-Browser: https://github.com/jow-/ucode
+Vcs-Git: https://github.com/jow-/ucode.git
+Bugs: https://github.com/jow-/ucode/issues
 
 Package: ucode
 Architecture: any

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Without this a build is failed on the Launchpad CI for PPA.
With the cmake the package was built and available here
https://code.launchpad.net/~stokito/+archive/ubuntu/openwrt

CC @aparcar