### PR TITLE
debian/control: libucode Recommends ucode-modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Package: ucode-modules
 Architecture: any
 Multi-Arch: foreign
 Depends: libucode (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Enhances: libucode
 Description: Extension modules for the ucode language
  Ucode is a tiny script language featuring ECMA script syntax, builtin JSON
  support and templating using Jinja inspired markup. The ucode VM is provided
@@ -45,6 +46,7 @@ Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends: ucode-modules
 Section: libs
 Description: Shared library for the ucode interpreter
  Ucode is a tiny script language featuring ECMA script syntax, builtin JSON


### PR DESCRIPTION
When installing the ucode with apt it doesn't install the ucode-modules by default.
I added it as a `Recommends:` dependency. Now it will be installed by default but you still can skip it.

[Declaring relationships between packages](https://www.debian.org/doc/debian-policy/ch-relationships.html)