### PR TITLE
docs: Fix compilation command for macOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ To build on MacOS, first install *cmake* and *json-c* via
     $ brew install cmake json-c
     $ git clone https://github.com/jow-/ucode.git
     $ cd ucode/
-    $ cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF .
+    $ cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF -DCMAKE_BUILD_RPATH=/usr/local/lib -DCMAKE_INSTALL_RPATH=/usr/local/lib .
     $ make
     $ sudo make install
 


### PR DESCRIPTION
Fixes: #265 "macOS build broken not finding libucode.0.dylib"

Suggested-by: Felix Fietkau <nbd@nbd.name>