### PR TITLE
debian: fix lintian warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,15 @@ examples/
 !/docs/ucode.css
 !/docs/.nojekyll
 !/docs/tutorials/
+/obj-*/
+/debian/.debhelper/
+/debian/tmp/
+/debian/ucode/
+/debian/libucode/
+/debian/libucode-dev/
+/debian/ucode-modules/
+/debian/debhelper-build-stamp
+/debian/files
+/debian/*.debhelper
+/debian/*.debhelper.log
+/debian/*.substvars

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ucode (0.0.20220322-1) UNRELEASED; urgency=medium
+ucode (0.0.20220322) UNRELEASED; urgency=medium
 
   * Initial release.
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: interpreters
 Priority: optional
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Build-Depends: debhelper-compat (= 12), cmake, pkg-config, libjson-c-dev
+Build-Depends: debhelper-compat (= 12), cmake, pkgconf, libjson-c-dev
 Homepage: https://github.com/jow-/ucode
 Vcs-Browser: https://github.com/jow-/ucode
 Vcs-Git: https://github.com/jow-/ucode.git

--- a/debian/copyright
+++ b/debian/copyright
@@ -10,7 +10,7 @@ License: ISC
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+ .
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
  AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,0 +1,1 @@
+no-manual-page


### PR DESCRIPTION
I used the debuild to build a package and it additionally runs lintian checks. Here are fixes of a few of them.

These two remains unfixed:

E: libucode: arch-dependent-file-not-in-arch-specific-directory [usr/lib/libucode.so.20220322]
W: libucode: package-name-doesnt-match-sonames libucode20220322

There is also an error that man pages are missing but I disabled it in the lintian-overrides file.
