### PR TITLE
socket: Introduce method socket.strerror() and do not clear last_error in socket.error() 

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -2320,6 +2320,45 @@ uc_socket_error(uc_vm_t *vm, size_t nargs)
 }
 
 /**
+ * Returns a string containing a description of the positive (`errno`) or
+ * negative (`EAI_*` constant) error code number given by the *code* argument.
+ *
+ * Returns `null` if the error code number is unknown.
+ *
+ * @function module:socket#strerror
+ *
+ * @param {number} code
+ * The error code.
+ *
+ * @returns {?string}
+ *
+ * @example
+ * // Should output 'Name or service not known'.
+ * print(socket.strerror(-2), '\n');
+ *
+ * // Should output 'No route to host'.
+ * print(socket.strerror(113), '\n');
+ */
+static uc_value_t *
+uc_socket_strerror(uc_vm_t *vm, size_t nargs)
+{
+	uc_value_t *codearg, *rv;
+	int code;
+
+	args_get(vm, nargs, NULL,
+		"code", UC_INTEGER, false, &codearg);
+
+	code = ucv_to_integer(codearg);
+
+	if (code < 0)
+		rv = ucv_string_new( gai_strerror(code) );
+	else
+		rv = ucv_string_new( strerror(code) );
+
+	ok_return(rv);
+}
+
+/**
  * @typedef {Object} module:socket.socket.SocketAddress
  * @property {number} family
  * Address family, one of AF_INET, AF_INET6, AF_UNIX or AF_PACKET.
@@ -4722,6 +4761,7 @@ static const uc_function_list_t global_fns[] = {
 	{ "connect",	uc_socket_connect },
 	{ "listen",		uc_socket_listen },
 	{ "error",		uc_socket_error },
+	{ "strerror",	uc_socket_strerror },
 };
 
 void uc_module_init(uc_vm_t *vm, uc_value_t *scope)

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -2316,7 +2316,7 @@ uc_socket_error(uc_vm_t *vm, size_t nargs)
 		rv = ucv_stringbuf_finish(buf);
 	}
 
-	ok_return(rv);
+	return rv;
 }
 
 /**


### PR DESCRIPTION
I was experimenting with the socket module to see if I can write a ping implementation. I found that it is impossible for me to retrieve both the error code and a string describing the error. I would have liked to try create a [ping socket](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=c319b4d76b9e583a5d88d6bf190e079c4e43213d) and if that fails with one of EAGAIN, EACCES or EPROTONOSUPPORT, create a raw socket instead. For all other error codes I would like to print a human readable description of the error.

This modifies socket.error() so that one can call socket.error() and subsequently socket.error(true) to retrieve both error code and description. Since the method itself can not generate any errors, this should not cause any problems.

One a side note, while reading through the code I noticed that peercred() also does not clear last_error on success. Is this on purpose?

Additionally introduce a new method strerror(code) that yields the description string for a given error code. This can be useful when the code is retrieved for example with recvmsg() in conjunction with the MSG_ERRQUEUE flag.