### PR TITLE
socker: let sock.peercred() clear error on success

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -4556,7 +4556,7 @@ uc_socket_inst_peercred(uc_vm_t *vm, size_t nargs)
 	err_return(ENOSYS, "Operation not supported on this system");
 #endif
 
-	return rv;
+	ok_return(rv);
 }
 
 /**


### PR DESCRIPTION
Align the behavior of this function with others and clear the current error information upon returning successfully.

Reported-by: @pony1k