### PR TITLE
Fixes for ubus binding issues

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -2375,8 +2375,11 @@ uc_ubus_channel_disconnect_cb(struct ubus_context *ctx)
 		c->ctx.sock.fd = -1;
 	}
 
-	if (c->registry_index >= 0)
-		connection_reg_clear(c->vm, c->registry_index);
+	if (c->registry_index >= 0) {
+		int idx = c->registry_index;
+		c->registry_index = -1;
+		connection_reg_clear(c->vm, idx);
+	}
 }
 
 static uc_value_t *

--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -636,6 +636,7 @@ uc_ubus_call_user_cb(uc_ubus_deferred_t *defer, int ret, uc_value_t *reply)
 	uc_value_t *this, *func;
 
 	request_reg_get(defer->vm, defer->registry_index, &this, &func, NULL, NULL);
+	ucv_get(this);
 
 	if (ucv_is_callable(func)) {
 		uc_vm_stack_push(defer->vm, ucv_get(this));
@@ -648,6 +649,7 @@ uc_ubus_call_user_cb(uc_ubus_deferred_t *defer, int ret, uc_value_t *reply)
 	}
 
 	request_reg_clear(defer->vm, defer->registry_index);
+	ucv_put(this);
 }
 
 static void


### PR DESCRIPTION
- Fix clobbering unrelated connections on channel disconnect
- fix use-after-free when using `reply()` on a deferred request