### PR TITLE
ucode: add padding to uc_resource_ext_t

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -213,6 +213,8 @@ typedef struct {
 	uint32_t persistent:1;
 	uint32_t uvcount:8;
 	uint32_t datasize:20;
+
+	uint32_t _pad;
 } uc_resource_ext_t;
 
 uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);


### PR DESCRIPTION
This ensures that user data structures tied to the ext resource are aligned to 64 bit, as usually guaranteed by the memory allocator.