### PR TITLE
ucode: Add 'operator execute'

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -575,18 +575,7 @@ ucv_to_unsigned(uc_value_t *v)
 	return u;
 }
 
-static inline bool
-ucv_is_callable(uc_value_t *uv)
-{
-	switch (ucv_type(uv)) {
-	case UC_CLOSURE:
-	case UC_CFUNCTION:
-		return true;
-
-	default:
-		return false;
-	}
-}
+bool ucv_is_callable(uc_value_t *uv);
 
 static inline bool
 ucv_is_arrowfn(uc_value_t *uv)

--- a/include/ucode/vm.h
+++ b/include/ucode/vm.h
@@ -161,4 +161,7 @@ uc_exception_type_t uc_vm_signal_dispatch(uc_vm_t *vm);
 void uc_vm_signal_raise(uc_vm_t *vm, int signo);
 int uc_vm_signal_notifyfd(uc_vm_t *vm);
 
+__hidden uc_value_t *uc_vm_get_invoke_fn( uc_value_t *proto );
+
+
 #endif /* UCODE_VM_H */

--- a/lib/math.c
+++ b/lib/math.c
@@ -372,16 +372,20 @@ uc_pow(uc_vm_t *vm, size_t nargs)
 }
 
 /**
- * Produces a pseudo-random positive integer.
+ * Depending on the arguments, it produces a pseudo-random positive integer, 
+ * or a pseudo-random number in a supplied range.
  *
- * Returns the calculated pseuo-random value. The value is within the range
- * `0` to `RAND_MAX` inclusive where `RAND_MAX` is a platform specific value
- * guaranteed to be at least `32767`.
- *
+ * Without arguments it returns the calculated pseuo-random value. The value 
+ * is within the range `0` to `RAND_MAX` inclusive where `RAND_MAX` is a platform 
+ * specific value guaranteed to be at least `32767`.
+ * 
+ * With 2 arguments `a, b` it returns a number in the range `a` to `b` inclusive.
+ * With a single argument `a` it returns a number in the range `0` to `a` inclusive.
+ * 
  * The {@link module:math~srand `srand()`} function sets its argument as the
- * seed for a new sequence of pseudo-random integers to be returned by `rand()`. These sequences are
- * repeatable by calling {@link module:math~srand `srand()`} with the same
- * seed value.
+ * seed for a new sequence of pseudo-random integers to be returned by `rand()`.
+ * These sequences are repeatable by calling {@link module:math~srand `srand()`}
+ * with the same seed value.
  *
  * If no seed value is explicitly set by calling
  * {@link module:math~srand `srand()`} prior to the first call to `rand()`,
@@ -390,6 +394,12 @@ uc_pow(uc_vm_t *vm, size_t nargs)
  *
  * @function module:math#rand
  *
+ * @param {number} [a]
+ * End of the desired range.
+ * 
+ * @param {number} [b]
+ * The other end of the desired range.
+ * 
  * @returns {number}
  */
 static uc_value_t *
@@ -404,7 +414,15 @@ uc_rand(uc_vm_t *vm, size_t nargs)
 		uc_vm_registry_set(vm, "math.srand_called", ucv_boolean_new(true));
 	}
 
-	return ucv_int64_new(rand());
+	if (nargs == 0)
+		return ucv_int64_new(rand());
+
+	double a = ucv_to_double(uc_fn_arg(0)), b = 0;
+
+	if (nargs > 1)
+		b = ucv_to_double(uc_fn_arg(1));
+
+	return ucv_double_new(a + ((b - a) * rand()) / RAND_MAX);
 }
 
 /**

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -3283,6 +3283,32 @@ uc_socket_create(uc_vm_t *vm, size_t nargs)
 }
 
 /**
+ * Creates a network socket instance from an existing file descriptor.
+ *
+ * Returns a socket descriptor representing the newly created socket.
+ *
+ * Returns `null` if an error occurred during socket creation.
+ *
+ * @function module:socket#open
+ *
+ * @param {number} [fd]
+ * The file descriptor number
+ *
+ * @returns {?module:socket.socket}
+ * A socket instance representing the socket.
+ */
+static uc_value_t *
+uc_socket_open(uc_vm_t *vm, size_t nargs)
+{
+	uc_value_t *fd;
+
+	args_get(vm, nargs, NULL,
+		"fd", UC_INTEGER, false, &fd);
+
+	ok_return(ucv_socket_new(vm, ucv_int64_get(fd)));
+}
+
+/**
  * Creates a connected socket instance with a pair file descriptor.
  *
  * This function creates new network sockets with the specified type,
@@ -4874,6 +4900,7 @@ static const uc_function_list_t global_fns[] = {
 	{ "sockaddr",	uc_socket_sockaddr },
 	{ "create",		uc_socket_create },
 	{ "pair",		uc_socket_pair },
+	{ "open",		uc_socket_open },
 	{ "nameinfo",	uc_socket_nameinfo },
 	{ "addrinfo",	uc_socket_addrinfo },
 	{ "poll",		uc_socket_poll },

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -3283,6 +3283,88 @@ uc_socket_create(uc_vm_t *vm, size_t nargs)
 }
 
 /**
+ * Creates a connected socket instance with a pair file descriptor.
+ *
+ * This function creates new network sockets with the specified type,
+ * determined by one of the `SOCK_*` constants, and returns resulting socket
+ * instances for use in subsequent socket operations.
+ *
+ * The type argument specifies the socket type, such as SOCK_STREAM or
+ * SOCK_DGRAM, and defaults to SOCK_STREAM if not provided. It may also
+ * be bitwise OR-ed with SOCK_NONBLOCK to enable non-blocking mode or
+ * SOCK_CLOEXEC to enable close-on-exec semantics.
+ *
+ * Returns an array of socket descriptors.
+ *
+ * Returns `null` if an error occurred during socket creation.
+ *
+ * @function module:socket#pair
+ *
+ * @param {number} [type=SOCK_STREAM]
+ * The socket type, e.g., SOCK_STREAM or SOCK_DGRAM. It may also be
+ * bitwise OR-ed with SOCK_NONBLOCK or SOCK_CLOEXEC.
+ *
+ * @returns {Array.<?module:socket.socket>}
+ * Socket instances representing the newly created sockets.
+ *
+ * @example
+ * // Create a TCP socket pair
+ * const tcp_sockets = pair(SOCK_STREAM);
+ *
+ * // Create a nonblocking IPv6 UDP socket pair
+ * const udp_sockets = pair(SOCK_DGRAM | SOCK_NONBLOCK);
+ */
+static uc_value_t *
+uc_socket_pair(uc_vm_t *vm, size_t nargs)
+{
+	uc_value_t *type, *res;
+	int sockfds[2], socktype;
+
+	args_get(vm, nargs, NULL,
+		"type", UC_INTEGER, true, &type);
+
+	socktype = type ? (int)ucv_int64_get(type) : SOCK_STREAM;
+
+	if (socketpair(AF_UNIX,
+#if defined(__APPLE__)
+		socktype & ~(SOCK_NONBLOCK|SOCK_CLOEXEC),
+#else
+		socktype,
+#endif
+		0, sockfds) < 0)
+		err_return(errno, "socketpair()");
+
+#if defined(__APPLE__)
+	if (socktype & SOCK_NONBLOCK) {
+		int flags = fcntl(sockfds[0], F_GETFL);
+
+		if (flags == -1)
+			goto error;
+
+		if (fcntl(sockfds[0], F_SETFL, flags | O_NONBLOCK) == -1)
+			goto error;
+	}
+
+	if (socktype & SOCK_CLOEXEC) {
+		if (fcntl(sockfds[0], F_SETFD, FD_CLOEXEC) == -1)
+			goto error;
+	}
+#endif
+
+	res = ucv_array_new(vm);
+	ucv_array_set(res, 0, ucv_socket_new(vm, sockfds[0]));
+	ucv_array_set(res, 1, ucv_socket_new(vm, sockfds[1]));
+	ok_return(res);
+
+#if defined(__APPLE__)
+error:
+#endif
+	close(sockfds[0]);
+	close(sockfds[1]);
+	err_return(errno, "fcntl");
+}
+
+/**
  * Connects the socket to a remote address.
  *
  * Attempts to establish a connection to the specified remote address.
@@ -4791,6 +4873,7 @@ static const uc_function_list_t socket_fns[] = {
 static const uc_function_list_t global_fns[] = {
 	{ "sockaddr",	uc_socket_sockaddr },
 	{ "create",		uc_socket_create },
+	{ "pair",		uc_socket_pair },
 	{ "nameinfo",	uc_socket_nameinfo },
 	{ "addrinfo",	uc_socket_addrinfo },
 	{ "poll",		uc_socket_poll },

--- a/types.c
+++ b/types.c
@@ -2182,6 +2182,21 @@ ucv_is_truish(uc_value_t *val)
 	}
 }
 
+bool
+ucv_is_callable(uc_value_t *uv)
+{
+	switch (ucv_type(uv)) {
+	case UC_CLOSURE:
+	case UC_CFUNCTION:
+		return true;
+
+	default:
+		if( uc_vm_get_invoke_fn( ucv_prototype_get( uv ) ) )
+			return true;
+		return false;
+	}
+}
+
 uc_value_t *
 ucv_to_number(uc_value_t *v)
 {


### PR DESCRIPTION
It can be useful to call a resource as if it was a function. This commit adds a way to do so.

When a non-callable is supplied to uc_vm_insn_call(), and it is an object or has a prototype, then the object/prototype stack is searched for a callable named 'operator()', and if found, that is called instead.

So in the script
var(...); is a functional synonym to var['operator()'](...);