### PR TITLE
vm,types: introduce dict type with value-key support

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -443,6 +443,40 @@ size_t ucv_object_length(uc_value_t *);
 	                 : 0);																		\
 	     entry##key = entry_next##key)
 
+/* dict (value-key object) detection via hash table equal_fn sentinel */
+extern int uc_dict_equal(const void *k1, const void *k2);
+
+static inline bool
+ucv_is_dict(uc_value_t *uv)
+{
+	uc_object_t *obj;
+
+	if (((uintptr_t)uv & 3) != 0 || uv == NULL || uv->type != UC_OBJECT)
+		return false;
+
+	obj = (uc_object_t *)uv;
+
+	return (obj->table->equal_fn == uc_dict_equal);
+}
+
+#define ucv_dict_foreach(dict, key, val)                                                       \
+	uc_value_t *key = NULL;                                                                      \
+	uc_value_t *val = NULL;                                                                      \
+	struct lh_entry *entry##key;                                                                 \
+	struct lh_entry *entry_next##key = NULL;                                                     \
+	for (entry##key = (ucv_type(dict) == UC_OBJECT) ? ((uc_object_t *)dict)->table->head : NULL; \
+	     (entry##key ? (key = (uc_value_t *)lh_entry_k(entry##key),                              \
+	                 val = (uc_value_t *)lh_entry_v(entry##key),                                 \
+	                 entry_next##key = entry##key->next, entry##key)                             \
+	              : 0);                                                                          \
+	     entry##key = entry_next##key)
+
+uc_value_t *ucv_dict_new(uc_vm_t *, uc_value_t *src);
+uc_value_t *ucv_dict_get(uc_vm_t *, uc_value_t *, uc_value_t *);
+uc_value_t *ucv_dict_set(uc_vm_t *, uc_value_t *, uc_value_t *, uc_value_t *);
+bool ucv_dict_delete(uc_vm_t *, uc_value_t *, uc_value_t *);
+size_t ucv_dict_length(uc_value_t *);
+
 uc_value_t *ucv_cfunction_new(const char *, uc_cfn_ptr_t);
 
 uc_value_t *ucv_closure_new(uc_vm_t *, uc_function_t *, bool);

--- a/lib.c
+++ b/lib.c
@@ -383,7 +383,9 @@ uc_length(uc_vm_t *vm, size_t nargs)
 
 	switch (ucv_type(arg)) {
 	case UC_OBJECT:
-		return ucv_int64_new(ucv_object_length(arg));
+		return ucv_int64_new(ucv_is_dict(arg)
+			? ucv_dict_length(arg)
+			: ucv_object_length(arg));
 
 	case UC_ARRAY:
 		return ucv_int64_new(ucv_array_length(arg));
@@ -843,6 +845,58 @@ uc_die(uc_vm_t *vm, size_t nargs)
 }
 
 /**
+ * Create a dictionary object with arbitrary value keys.
+ *
+ * Unlike regular objects which are limited to string keys, dictionary objects
+ * allow any ucode value as a key. Key uniqueness follows the same semantics as
+ * the {@link module:core#uniq|uniq()} function:
+ *
+ *  - Scalar values (null, boolean, integer, double, string): compared by value
+ *  - Non-scalar values (arrays, objects, resources, closures): compared by
+ *    reference (pointer equality)
+ *  - NaN doubles are treated as equal
+ *
+ * If an existing object, dict or array is passed as argument, its entries
+ * are copied into the new dictionary:
+ *
+ *  - Objects: string keys become string-value keys in the dict
+ *  - Dicts: value keys are copied as-is
+ *  - Arrays: numeric indices become integer-value keys
+ *
+ * @function module:core#dict
+ *
+ * @param {?*} [src=null]
+ * An optional source object, dict, or array to initialize from.
+ *
+ * @returns {Object}
+ * A new dictionary object.
+ *
+ * @example
+ * let d = dict();
+ * d[true] = "yes";
+ * d[false] = "no";
+ * d[42] = "answer";
+ * d["foo"] = "bar";
+ *
+ * // keys() returns actual key values
+ * keys(d);  // [true, false, 42, "foo"]
+ *
+ * // initialize from an existing object
+ * let d2 = dict({ a: 1, b: 2 });
+ * d2["a"];  // 1
+ *
+ * // spread dict into regular object (keys converted to strings)
+ * let obj = { ...d };
+ */
+static uc_value_t *
+uc_dict(uc_vm_t *vm, size_t nargs)
+{
+	uc_value_t *src = uc_fn_arg(0);
+
+	return ucv_dict_new(vm, src);
+}
+
+/**
  * Check whether the given key exists within the given object value.
  *
  * Returns `true` if the given key is present within the object passed as the
@@ -871,16 +925,24 @@ uc_exists(uc_vm_t *vm, size_t nargs)
 	uc_value_t *key = uc_fn_arg(1);
 	bool found, freeable;
 	char *k;
+	uc_value_t *v;
 
 	if (ucv_type(obj) != UC_OBJECT)
 		return ucv_boolean_new(false);
 
-	k = uc_cast_string(vm, &key, &freeable);
+	if (ucv_is_dict(obj)) {
+		v = ucv_dict_get(vm, obj, key);
+		found = (v != NULL);
+		if (v)
+			ucv_put(v);
+	} else {
+		k = uc_cast_string(vm, &key, &freeable);
 
-	ucv_object_get(obj, k, &found);
+		ucv_object_get(obj, k, &found);
 
-	if (freeable)
-		free(k);
+		if (freeable)
+			free(k);
+	}
 
 	return ucv_boolean_new(found);
 }
@@ -1183,9 +1245,17 @@ uc_keys(uc_vm_t *vm, size_t nargs)
 
 	arr = ucv_array_new(vm);
 
-	ucv_object_foreach(obj, key, val) {
-		(void)val;
-		ucv_array_push(arr, ucv_string_new(key));
+	if (ucv_is_dict(obj)) {
+		/* dict keys are values, return them directly */
+		ucv_dict_foreach(obj, key, val) {
+			(void)val;
+			ucv_array_push(arr, ucv_get(key));
+		}
+	} else {
+		ucv_object_foreach(obj, key, val) {
+			(void)val;
+			ucv_array_push(arr, ucv_string_new(key));
+		}
 	}
 
 	return arr;
@@ -2192,9 +2262,16 @@ uc_values(uc_vm_t *vm, size_t nargs)
 
 	arr = ucv_array_new(vm);
 
-	ucv_object_foreach(obj, key, val) {
-		(void)key;
-		ucv_array_push(arr, ucv_get(val));
+	if (ucv_is_dict(obj)) {
+		ucv_dict_foreach(obj, key, val) {
+			(void)key;
+			ucv_array_push(arr, ucv_get(val));
+		}
+	} else {
+		ucv_object_foreach(obj, key, val) {
+			(void)key;
+			ucv_array_push(arr, ucv_get(val));
+		}
 	}
 
 	return arr;
@@ -6037,6 +6114,7 @@ uc_signal(uc_vm_t *vm, size_t nargs)
 const uc_function_list_t uc_stdlib_functions[] = {
 	{ "chr",		uc_chr },
 	{ "die",		uc_die },
+	{ "dict",		uc_dict },
 	{ "exists",		uc_exists },
 	{ "exit",		uc_exit },
 	{ "filter",		uc_filter },

--- a/tests/custom/03_stdlib/69_dict
+++ b/tests/custom/03_stdlib/69_dict
@@ -1,0 +1,600 @@
+The `dict()` function creates a dictionary with arbitrary ucode value keys,
+instead of being limited to string keys as regular objects are.
+
+Key uniqueness follows `uc_uniq()` semantics:
+- Scalars (null, bool, int, double, string) are compared by value
+- Non-scalars (arrays, objects, etc.) are compared by pointer equality
+- NaN doubles are treated as equal
+
+1. Create an empty dictionary.
+
+-- Testcase --
+{%
+	let d = dict();
+	printf("%.J\n", [ type(d), length(d) ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	"object",
+	0
+]
+-- End --
+
+
+2. Create dictionary from an object (string keys become string value keys).
+
+-- Testcase --
+{%
+	let d = dict({ "a": 1, "b": 2 });
+	printf("%.J\n", [ length(d), d["a"], d["b"] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	2,
+	1,
+	2
+]
+-- End --
+
+
+3. Create dictionary from an array (numeric indices become integer keys).
+
+-- Testcase --
+{%
+	let d = dict([ 10, 20, 30 ]);
+	printf("%.J\n", [ length(d), d[0], d[1], d[2] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	3,
+	10,
+	20,
+	30
+]
+-- End --
+
+
+4. Create dictionary from another dict.
+
+-- Testcase --
+{%
+	let d1 = dict();
+	d1[42] = "answer";
+	d1[true] = "yes";
+	let d2 = dict(d1);
+	printf("%.J\n", [ length(d2), d2[42], d2[true] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	2,
+	"answer",
+	"yes"
+]
+-- End --
+
+
+5. Dict with various scalar key types (bool, int, float, null, string).
+
+-- Testcase --
+{%
+	let d = dict();
+	d[true] = "yes";
+	d[false] = "no";
+	d[42] = "answer";
+	d[-1] = "neg";
+	d[0] = "zero";
+	d[3.14] = "pi";
+	d[null] = "nil";
+	d["foo"] = "bar";
+
+	printf("%.J\n", [
+		length(d),
+		d[true], d[false],
+		d[42], d[-1], d[0],
+		d[3.14],
+		d[null],
+		d["foo"]
+	]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	8,
+	"yes",
+	"no",
+	"answer",
+	"neg",
+	"zero",
+	"pi",
+	"nil",
+	"bar"
+]
+-- End --
+
+
+6. NaN keys are treated as equal (single NaN slot).
+
+-- Testcase --
+{%
+	let d = dict();
+	let n1 = json("NaN");
+	let n2 = json("NaN");
+	d[n1] = "first";
+	d[n2] = "second";
+	printf("%.J\n", [ length(d), d[n1], d[n2] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	1,
+	"second",
+	"second"
+]
+-- End --
+
+
+7. Array keys use pointer equality (different array instances = different keys).
+
+-- Testcase --
+{%
+	let d = dict();
+	let a1 = [ 1, 2, 3 ];
+	let a2 = [ 1, 2, 3 ];
+	d[a1] = "first";
+	d[a2] = "second";
+	printf("%.J\n", [ length(d), d[a1], d[a2] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	2,
+	"first",
+	"second"
+]
+-- End --
+
+
+8. Array keys use pointer equality (same reference = same key).
+
+-- Testcase --
+{%
+	let d = dict();
+	let a = [ 1, 2, 3 ];
+	d[a] = "first";
+	d[a] = "second";
+	printf("%.J\n", [ length(d), d[a] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	1,
+	"second"
+]
+-- End --
+
+
+9. Object keys use pointer equality.
+
+-- Testcase --
+{%
+	let d = dict();
+	let o1 = { x: 1 };
+	let o2 = { x: 1 };
+	d[o1] = "first";
+	d[o2] = "second";
+	printf("%.J\n", [ length(d), d[o1], d[o2] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	2,
+	"first",
+	"second"
+]
+-- End --
+
+
+10. Update existing key preserves key count.
+
+-- Testcase --
+{%
+	let d = dict();
+	d[1] = "a";
+	d[2] = "b";
+	d[3] = "c";
+	d[2] = "updated";
+	printf("%.J\n", [ length(d), d[2] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	3,
+	"updated"
+]
+-- End --
+
+
+11. Delete key from dict.
+
+-- Testcase --
+{%
+	let d = dict();
+	d["a"] = 1;
+	d["b"] = 2;
+	d["c"] = 3;
+	delete d["b"];
+	printf("%.J\n", [ length(d), d["a"], d["b"], d["c"] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	2,
+	1,
+	null,
+	3
+]
+-- End --
+
+
+12. keys() on dict returns actual value keys.
+
+-- Testcase --
+{%
+	let d = dict();
+	d[42] = "x";
+	d[true] = "y";
+	d["foo"] = "z";
+	let k = keys(d);
+	printf("%.J\n", [ length(k), type(k[0]), type(k[1]), type(k[2]) ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	3,
+	"int",
+	"bool",
+	"string"
+]
+-- End --
+
+
+13. values() on dict.
+
+-- Testcase --
+{%
+	let d = dict();
+	d[1] = "a";
+	d[2] = "b";
+	d[3] = "c";
+	printf("%.J\n", values(d));
+%}
+-- End --
+
+-- Expect stdout --
+[
+	"a",
+	"b",
+	"c"
+]
+-- End --
+
+
+14. exists() on dict with value keys.
+
+-- Testcase --
+{%
+	let d = dict();
+	d[42] = "answer";
+	d["foo"] = "bar";
+	d[true] = "yes";
+	printf("%.J\n", [
+		exists(d, 42),
+		exists(d, "foo"),
+		exists(d, true),
+		exists(d, "missing")
+	]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	true,
+	true,
+	true,
+	false
+]
+-- End --
+
+
+15. length() on dict.
+
+-- Testcase --
+{%
+	let d = dict();
+	print(length(d), "\n");
+	d[1] = "a";
+	print(length(d), "\n");
+	d[2] = "b";
+	d[3] = "c";
+	print(length(d), "\n");
+%}
+-- End --
+
+-- Expect stdout --
+0
+1
+3
+-- End --
+
+
+16. Spread dict into object (value keys converted to strings).
+
+-- Testcase --
+{%
+	let d = dict();
+	d[true] = "yes";
+	d[42] = "answer";
+	d["foo"] = "bar";
+	let o = { prefix: 1, ...d, suffix: 2 };
+	printf("%.J\n", [
+		o["true"], o["42"], o["foo"],
+		o["prefix"], o["suffix"]
+	]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	"yes",
+	"answer",
+	"bar",
+	1,
+	2
+]
+-- End --
+
+
+17. Spread object into dict (string keys preserved as string values).
+
+-- Testcase --
+{%
+	let o = { a: 1, b: 2, c: 3 };
+	let d = dict(o);
+	printf("%.J\n", [ length(d), d["a"], d["b"], d["c"] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	3,
+	1,
+	2,
+	3
+]
+-- End --
+
+
+18. Spread dict into dict.
+
+-- Testcase --
+{%
+	let d1 = dict();
+	d1[99] = "ninety-nine";
+	d1[true] = "yes";
+	let d2 = dict(d1);
+	d2[100] = "hundred";
+	printf("%.J\n", [ length(d2), d2[99], d2[true], d2[100] ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	3,
+	"ninety-nine",
+	"yes",
+	"hundred"
+]
+-- End --
+
+
+19. for...in iteration yields value keys.
+
+-- Testcase --
+{%
+	let d = dict();
+	d["a"] = 1;
+	d["b"] = 2;
+	d["c"] = 3;
+	let collected = [];
+
+	for (let k in d)
+		push(collected, k);
+
+	printf("%.J\n", collected);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	"a",
+	"b",
+	"c"
+]
+-- End --
+
+
+20. for...in iteration with non-string keys.
+
+-- Testcase --
+{%
+	let d = dict();
+	d[10] = "x";
+	d[20] = "y";
+	let sum = 0;
+
+	for (let k in d)
+		sum += k;
+
+	print(sum, "\n");
+%}
+-- End --
+
+-- Expect stdout --
+30
+-- End --
+
+
+21. Dict with prototype chain (regular object proto).
+
+-- Testcase --
+{%
+	let d = dict();
+	let p = { shared: "value" };
+	proto(d, p);
+	print(d.shared, "\n");
+%}
+-- End --
+
+-- Expect stdout --
+value
+-- End --
+
+
+22. Dict with dict prototype.
+
+-- Testcase --
+{%
+	let pd = dict();
+	pd[true] = "from-prototype";
+	pd[42] = "answer";
+	let d = dict();
+	proto(d, pd);
+	printf("%.J\n", [ d[true], d[42], length(d) ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	"from-prototype",
+	"answer",
+	0
+]
+-- End --
+
+
+23. Dict value increment and decrement.
+
+-- Testcase --
+{%
+	let d = dict();
+	d["n"] = 10;
+	d["n"]++;
+	d["n"] += 5;
+	d["n"]--;
+	d["n"] -= 3;
+	print(d["n"], "\n");
+%}
+-- End --
+
+-- Expect stdout --
+12
+-- End --
+
+
+24. Dict GC stress test (no leaks with many dicts and keys).
+
+-- Testcase --
+{%
+	for (let i = 0; i < 1000; i++) {
+		let d = dict();
+		for (let j = 0; j < 50; j++) {
+			d[j] = j * 2;
+			d["k" + j] = "str-" + j;
+			d[true] = "bool";
+		}
+	}
+
+	gc();
+	print("ok\n");
+%}
+-- End --
+
+-- Expect stdout --
+ok
+-- End --
+
+
+25. Dict JSON serialization (value keys converted to JSON strings).
+
+-- Testcase --
+{%
+	let d = dict();
+	d[true] = "yes";
+	d[42] = "answer";
+	d["foo"] = "bar";
+	d[null] = "nil";
+	printf("%.J\n", d);
+%}
+-- End --
+
+-- Expect stdout --
+{
+	"true": "yes",
+	"42": "answer",
+	"foo": "bar",
+	"null": "nil"
+}
+-- End --
+
+
+26. Dict plain stringification (computed property expressions).
+
+-- Testcase --
+{%
+	let d = dict();
+	d[true] = "yes";
+	d[42] = "answer";
+	d["foo"] = "bar";
+	print(d, "\n");
+%}
+-- End --
+
+-- Expect stdout --
+{ [true]: "yes", [42]: "answer", ["foo"]: "bar" }
+-- End --
+
+
+27. Dict with complex keys serializes correctly.
+
+-- Testcase --
+{%
+	let d = dict();
+	let a = [ 1, 2 ];
+	d[a] = "array-key";
+	d[3.14] = "pi";
+	printf("%.J\n", d);
+%}
+-- End --
+
+-- Expect stdout --
+{
+	"[ 1, 2 ]": "array-key",
+	"3.14": "pi"
+}
+-- End --

--- a/types.c
+++ b/types.c
@@ -188,8 +188,16 @@ ucv_gc_mark(uc_value_t *uv)
 
 		ucv_gc_mark(object->proto);
 
-		lh_foreach(object->table, entry)
-			ucv_gc_mark((uc_value_t *)lh_entry_v(entry));
+		if (ucv_is_dict(uv)) {
+			/* dict keys are uc_value_t* and must be GC'd */
+			lh_foreach(object->table, entry) {
+				ucv_gc_mark((uc_value_t *)lh_entry_k(entry));
+				ucv_gc_mark((uc_value_t *)lh_entry_v(entry));
+			}
+		} else {
+			lh_foreach(object->table, entry)
+				ucv_gc_mark((uc_value_t *)lh_entry_v(entry));
+		}
 
 		break;
 
@@ -1193,6 +1201,311 @@ ucv_object_length(uc_value_t *uv)
 }
 
 
+/* ---------------------------------------------------------------------------
+ * Dict (value-key object) implementation
+ *
+ * Dicts are objects where keys are arbitrary ucode values rather than
+ * null-terminated strings.  Uniqueness semantics follow uc_uniq():
+ *   - Scalars (null, bool, int, double, string): value equality
+ *   - Non-scalars (arrays, objects, resources, closures): pointer equality
+ *   - NaN doubles are treated as equal for hashing purposes
+ * --------------------------------------------------------------------------- */
+
+static void
+ucv_free_dict_entry(struct lh_entry *entry)
+{
+	/* update iterator positions affected by entry deletion */
+	uc_list_foreach(item, &uc_thread_context_get()->object_iterators) {
+		uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
+
+		if (iter->u.pos == entry)
+			iter->u.pos = entry->next;
+	}
+
+	/* keys are uc_value_t pointers — release the reference */
+	ucv_put((uc_value_t *)lh_entry_k(entry));
+	ucv_put(lh_entry_v(entry));
+}
+
+static unsigned long
+uc_dict_hash(const void *k)
+{
+	union { double d; int64_t i; uint64_t u; } conv;
+	uc_value_t *uv = (uc_value_t *)k;
+	unsigned int h;
+	uint8_t *u8;
+	size_t len;
+
+	h = ucv_type(uv);
+
+	switch (h) {
+	case UC_STRING:
+		u8 = (uint8_t *)ucv_string_get(uv);
+		len = ucv_string_length(uv);
+		if (!u8)
+			len = 0;
+		break;
+
+	case UC_INTEGER:
+		conv.i = ucv_int64_get(uv);
+
+		if (errno == ERANGE) {
+			h *= 2;
+			conv.u = ucv_uint64_get(uv);
+		}
+
+		u8 = (uint8_t *)&conv.u;
+		len = sizeof(conv.u);
+		break;
+
+	case UC_DOUBLE:
+		conv.d = ucv_double_get(uv);
+
+		u8 = (uint8_t *)&conv.u;
+		len = sizeof(conv.u);
+		break;
+
+	default:
+		u8 = (uint8_t *)&uv;
+		len = sizeof(uv);
+		break;
+	}
+
+	while (len > 0) {
+		h = h * 129 + (*u8++) + LH_PRIME;
+		len--;
+	}
+
+	return h;
+}
+
+int
+uc_dict_equal(const void *k1, const void *k2)
+{
+	uc_value_t *uv1 = (uc_value_t *)k1;
+	uc_value_t *uv2 = (uc_value_t *)k2;
+
+	/* non-scalar keys use pointer equality */
+	if (!ucv_is_scalar(uv1) && !ucv_is_scalar(uv2))
+		return (uv1 == uv2);
+
+	/* treat two NaNs as equal for dict key lookup */
+	if (ucv_type(uv1) == UC_DOUBLE && ucv_type(uv2) == UC_DOUBLE &&
+	    isnan(ucv_double_get(uv1)) && isnan(ucv_double_get(uv2)))
+		return true;
+
+	return ucv_is_equal(uv1, uv2);
+}
+
+uc_value_t *
+ucv_dict_new(uc_vm_t *vm, uc_value_t *src)
+{
+	struct lh_table *table;
+	uc_object_t *dict;
+	unsigned long hash;
+	size_t i;
+
+	table = lh_table_new(16, ucv_free_dict_entry, uc_dict_hash, uc_dict_equal);
+
+	if (!table) {
+		fprintf(stderr, "Out of memory\n");
+		abort();
+	}
+
+	dict = xalloc(sizeof(*dict));
+	dict->header.type = UC_OBJECT;
+	dict->header.refcount = 1;
+	dict->table = table;
+	dict->proto = NULL;
+	dict->ref.prev = NULL;
+	dict->ref.next = NULL;
+
+	/* initialize from source object or dict */
+	if (src) {
+		if (ucv_is_dict(src)) {
+			ucv_dict_foreach(src, k, v) {
+				hash = lh_get_hash(dict->table, k);
+				lh_table_insert_w_hash(dict->table, ucv_get(k), ucv_get(v), hash, 0);
+			}
+		} else if (ucv_type(src) == UC_OBJECT) {
+			ucv_object_foreach(src, k, v) {
+				uc_value_t *key = ucv_string_new(k);
+
+				hash = lh_get_hash(dict->table, key);
+				lh_table_insert_w_hash(dict->table, key, ucv_get(v), hash, 0);
+			}
+		} else if (ucv_type(src) == UC_ARRAY) {
+			for (i = 0; i < ucv_array_length(src); i++) {
+				uc_value_t *key = ucv_int64_new((int64_t)i);
+				uc_value_t *val = ucv_get(ucv_array_get(src, i));
+
+				hash = lh_get_hash(dict->table, key);
+				lh_table_insert_w_hash(dict->table, key, val, hash, 0);
+			}
+		}
+	}
+
+	if (vm) {
+		ucv_ref(&vm->values, &dict->ref);
+		vm->alloc_refs++;
+	}
+
+	return &dict->header;
+}
+
+uc_value_t *
+ucv_dict_get(uc_vm_t *vm, uc_value_t *dict, uc_value_t *key)
+{
+	uc_object_t *obj;
+	uc_value_t *val = NULL;
+	bool found;
+
+	if (!ucv_is_dict(dict))
+		return NULL;
+
+	obj = (uc_object_t *)dict;
+
+	/* try dict itself first */
+	found = lh_table_lookup_ex(obj->table, key, (void **)&val);
+
+	/* walk prototype chain if not found */
+	if (!found) {
+		uc_value_t *proto;
+
+		for (proto = obj->proto; proto; proto = ucv_prototype_get(proto)) {
+			if (ucv_type(proto) != UC_OBJECT)
+				continue;
+
+			if (ucv_is_dict(proto)) {
+				uc_object_t *pro = (uc_object_t *)proto;
+
+				if (lh_table_lookup_ex(pro->table, key, (void **)&val))
+					break;
+			} else {
+				/* convert key to string for regular object lookup */
+				char *s;
+				bool freeable;
+
+				if (ucv_type(key) == UC_STRING) {
+					s = ucv_string_get(key);
+					freeable = false;
+				} else {
+					s = ucv_to_string(vm, key);
+					freeable = true;
+				}
+
+				val = ucv_object_get(proto, s ? s : "", &found);
+
+				if (freeable)
+					free(s);
+
+				if (found)
+					break;
+			}
+		}
+	}
+
+	if (!val)
+		return NULL;
+
+	return ucv_get(val);
+}
+
+uc_value_t *
+ucv_dict_set(uc_vm_t *vm, uc_value_t *dict, uc_value_t *key, uc_value_t *val)
+{
+	uc_object_t *obj;
+	struct lh_entry *existing;
+	unsigned long hash;
+	bool rehash;
+	(void)vm;
+
+	if (!ucv_is_dict(dict))
+		return NULL;
+
+	if (ucv_is_constant(dict))
+		return NULL;
+
+	obj = (uc_object_t *)dict;
+	hash = lh_get_hash(obj->table, key);
+	existing = lh_table_lookup_entry_w_hash(obj->table, key, hash);
+
+	if (existing) {
+		ucv_put((uc_value_t *)existing->v);
+		existing->v = val;
+	} else {
+		rehash = (obj->table->count >= obj->table->size * LH_LOAD_FACTOR);
+
+		/* backup iterator states before potential rehash */
+		if (rehash) {
+			uc_list_foreach(item, &uc_thread_context_get()->object_iterators) {
+				uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
+
+				if (iter->table != obj->table)
+					continue;
+
+				if (iter->u.pos == NULL)
+					continue;
+
+				iter->u.kh.k = iter->u.pos->k;
+				iter->u.kh.hash = lh_get_hash(iter->table, iter->u.kh.k);
+			}
+		}
+
+		lh_table_insert_w_hash(obj->table, ucv_get(key), val, hash, 0);
+
+		/* restore iterator states after rehash */
+		if (rehash) {
+			uc_list_foreach(item, &uc_thread_context_get()->object_iterators) {
+				uc_object_iterator_t *iter = (uc_object_iterator_t *)item;
+
+				if (iter->table != obj->table)
+					continue;
+
+				if (iter->u.kh.k == NULL)
+					continue;
+
+				iter->u.pos = lh_table_lookup_entry_w_hash(iter->table,
+				                                             iter->u.kh.k,
+				                                             iter->u.kh.hash);
+			}
+		}
+	}
+
+	return ucv_get(val);
+}
+
+bool
+ucv_dict_delete(uc_vm_t *vm, uc_value_t *dict, uc_value_t *key)
+{
+	uc_object_t *obj;
+	(void)vm;
+
+	if (!ucv_is_dict(dict))
+		return false;
+
+	if (ucv_is_constant(dict))
+		return false;
+
+	obj = (uc_object_t *)dict;
+
+	return (lh_table_delete(obj->table, key) == 0);
+}
+
+size_t
+ucv_dict_length(uc_value_t *dict)
+{
+	uc_object_t *obj;
+
+	if (!ucv_is_dict(dict))
+		return 0;
+
+	obj = (uc_object_t *)dict;
+
+	return lh_table_length(obj->table);
+}
+
+
 uc_value_t *
 ucv_cfunction_new(const char *name, uc_cfn_ptr_t fptr)
 {
@@ -1635,8 +1948,17 @@ ucv_to_json(uc_value_t *uv)
 	case UC_OBJECT:
 		jso = json_object_new_object();
 
-		ucv_object_foreach(uv, key, val)
-			json_object_object_add(jso, key, ucv_to_json(val));
+		if (ucv_is_dict(uv)) {
+			ucv_dict_foreach(uv, key, val) {
+				char *s = ucv_to_string(NULL, key);
+
+				json_object_object_add(jso, s ? s : "", ucv_to_json(val));
+				free(s);
+			}
+		} else {
+			ucv_object_foreach(uv, key, val)
+				json_object_object_add(jso, key, ucv_to_json(val));
+		}
 
 		return jso;
 
@@ -1897,14 +2219,37 @@ ucv_to_stringbuf_formatted(uc_vm_t *vm, uc_stringbuf_t *pb, uc_value_t *uv, size
 		ucv_stringbuf_append(pb, "{");
 
 		i = 0;
-		ucv_object_foreach(uv, key, val) {
-			if (i++)
-				ucv_stringbuf_append(pb, ",");
+		if (ucv_is_dict(uv)) {
+			ucv_dict_foreach(uv, key, val) {
+				if (i++)
+					ucv_stringbuf_append(pb, ",");
 
-			ucv_to_stringbuf_add_padding(pb, pad_char, (depth + 1) * pad_size);
-			ucv_to_string_json_encoded(pb, key, strlen(key), false);
-			ucv_stringbuf_append(pb, ": ");
-			ucv_to_stringbuf_formatted(vm, pb, val, depth + 1, pad_char ? pad_char : '\1', pad_size);
+				ucv_to_stringbuf_add_padding(pb, pad_char, (depth + 1) * pad_size);
+				if (json) {
+					/* JSON mode: stringify value key to a JSON string */
+					s = ucv_to_string(vm, key);
+					l = s ? strlen(s) : 0;
+					ucv_to_string_json_encoded(pb, s, l, false);
+					free(s);
+				} else {
+					/* plain mode: emit key as a computed property expression */
+					ucv_stringbuf_append(pb, "[");
+					ucv_to_stringbuf_formatted(vm, pb, key, depth + 1, pad_char ? pad_char : '\1', pad_size);
+					ucv_stringbuf_append(pb, "]");
+				}
+				ucv_stringbuf_append(pb, ": ");
+				ucv_to_stringbuf_formatted(vm, pb, val, depth + 1, pad_char ? pad_char : '\1', pad_size);
+			}
+		} else {
+			ucv_object_foreach(uv, key, val) {
+				if (i++)
+					ucv_stringbuf_append(pb, ",");
+
+				ucv_to_stringbuf_add_padding(pb, pad_char, (depth + 1) * pad_size);
+				ucv_to_string_json_encoded(pb, key, strlen(key), false);
+				ucv_stringbuf_append(pb, ": ");
+				ucv_to_stringbuf_formatted(vm, pb, val, depth + 1, pad_char ? pad_char : '\1', pad_size);
+			}
 		}
 
 		ucv_to_stringbuf_add_padding(pb, pad_char, depth * pad_size);

--- a/vm.c
+++ b/vm.c
@@ -1238,7 +1238,9 @@ uc_vm_insn_load_val(uc_vm_t *vm, uc_vm_insn_t insn)
 	case UC_RESOURCE:
 	case UC_OBJECT:
 	case UC_ARRAY:
-		uc_vm_stack_push(vm, ucv_key_get(vm, v, k));
+		uc_vm_stack_push(vm, ucv_is_dict(v)
+			? ucv_dict_get(vm, v, k)
+			: ucv_key_get(vm, v, k));
 		break;
 
 	default:
@@ -1263,7 +1265,9 @@ uc_vm_insn_peek_val(uc_vm_t *vm, uc_vm_insn_t insn)
 	case UC_RESOURCE:
 	case UC_OBJECT:
 	case UC_ARRAY:
-		uc_vm_stack_push(vm, ucv_key_get(vm, v, k));
+		uc_vm_stack_push(vm, ucv_is_dict(v)
+			? ucv_dict_get(vm, v, k)
+			: ucv_key_get(vm, v, k));
 		break;
 
 	default:
@@ -1459,7 +1463,9 @@ uc_vm_insn_store_val(uc_vm_t *vm, uc_vm_insn_t insn)
 	case UC_OBJECT:
 	case UC_ARRAY:
 		if (assert_mutable_value(vm, o)) {
-			uc_value_t *rv = ucv_key_set(vm, o, k, v);
+			uc_value_t *rv = ucv_is_dict(o)
+			    ? ucv_dict_set(vm, o, k, v)
+			    : ucv_key_set(vm, o, k, v);
 
 			/* on success rv is a reference to the stored value that gets
 			 * pushed onto the stack; clear v so the cleanup below does not
@@ -1942,9 +1948,13 @@ uc_vm_insn_update_val(uc_vm_t *vm, uc_vm_insn_t insn)
 		if (assert_mutable_value(vm, v)) {
 			uc_value_t *nv, *rv;
 
-			val = ucv_key_get(vm, v, k);
+			val = ucv_is_dict(v)
+			    ? ucv_dict_get(vm, v, k)
+			    : ucv_key_get(vm, v, k);
 			nv = uc_vm_value_arith(vm, vm->arg.u8, val, inc);
-			rv = ucv_key_set(vm, v, k, nv);
+			rv = ucv_is_dict(v)
+			    ? ucv_dict_set(vm, v, k, nv)
+			    : ucv_key_set(vm, v, k, nv);
 
 			/* on success rv is a reference to the stored value that gets
 			 * pushed onto the stack; on failure nv was not stored, so
@@ -2077,10 +2087,17 @@ uc_vm_insn_sobj(uc_vm_t *vm, uc_vm_insn_t insn)
 	uc_value_t *obj = uc_vm_stack_peek(vm, vm->arg.u32);
 	size_t idx;
 
-	for (idx = 0; idx < vm->arg.u32; idx += 2)
-		ucv_key_set(vm, obj,
-			uc_vm_stack_peek(vm, vm->arg.u32 - idx - 1),
-			uc_vm_stack_peek(vm, vm->arg.u32 - idx - 2));
+	if (ucv_is_dict(obj)) {
+		for (idx = 0; idx < vm->arg.u32; idx += 2)
+			ucv_dict_set(vm, obj,
+				uc_vm_stack_peek(vm, vm->arg.u32 - idx - 1),
+				uc_vm_stack_peek(vm, vm->arg.u32 - idx - 2));
+	} else {
+		for (idx = 0; idx < vm->arg.u32; idx += 2)
+			ucv_key_set(vm, obj,
+				uc_vm_stack_peek(vm, vm->arg.u32 - idx - 1),
+				uc_vm_stack_peek(vm, vm->arg.u32 - idx - 2));
+	}
 
 	for (idx = 0; idx < vm->arg.u32; idx++)
 		ucv_put(uc_vm_stack_pop(vm));
@@ -2091,23 +2108,51 @@ uc_vm_insn_mobj(uc_vm_t *vm, uc_vm_insn_t insn)
 {
 	uc_value_t *src = uc_vm_stack_pop(vm);
 	uc_value_t *dst = uc_vm_stack_peek(vm, 0);
+	bool dst_is_dict = ucv_is_dict(dst);
 	size_t i;
 	char *s;
 
 	switch (ucv_type(src)) {
 	case UC_OBJECT:
-		; /* a label can only be part of a statement and a declaration is not a statement */
-		ucv_object_foreach(src, k, v)
-			ucv_object_add(dst, k, ucv_get(v));
+		if (ucv_is_dict(src)) {
+			/* spread dict into object or dict */
+			ucv_dict_foreach(src, k, v) {
+				if (dst_is_dict) {
+					ucv_dict_set(vm, dst, k, ucv_get(v));
+				} else {
+					/* convert value key to string for regular object */
+					s = ucv_to_string(vm, k);
+					ucv_object_add(dst, s ? s : "", ucv_get(v));
+					free(s);
+				}
+			}
+		} else if (dst_is_dict) {
+			/* spread regular object into dict — keys become string values */
+			ucv_object_foreach(src, k, v) {
+				uc_value_t *key = ucv_string_new(k);
+
+				ucv_dict_set(vm, dst, key, ucv_get(v));
+			}
+		} else {
+			/* spread regular object into regular object */
+			ucv_object_foreach(src, k, v)
+				ucv_object_add(dst, k, ucv_get(v));
+		}
 
 		ucv_put(src);
 		break;
 
 	case UC_ARRAY:
 		for (i = 0; i < ucv_array_length(src); i++) {
-			xasprintf(&s, "%zu", i);
-			ucv_object_add(dst, s, ucv_get(ucv_array_get(src, i)));
-			free(s);
+			if (dst_is_dict) {
+				uc_value_t *key = ucv_int64_new((int64_t)i);
+
+				ucv_dict_set(vm, dst, key, ucv_get(ucv_array_get(src, i)));
+			} else {
+				xasprintf(&s, "%zu", i);
+				ucv_object_add(dst, s, ucv_get(ucv_array_get(src, i)));
+				free(s);
+			}
 		}
 
 		ucv_put(src);
@@ -2413,6 +2458,7 @@ uc_vm_object_iterator_next(uc_vm_t *vm, uc_vm_insn_t insn,
 	uc_resource_t *res = (uc_resource_t *)k;
 	uc_object_t *obj = (uc_object_t *)v;
 	uc_object_iterator_t *iter;
+	bool is_dict;
 
 	if (!res) {
 		/* object is empty */
@@ -2448,7 +2494,12 @@ uc_vm_object_iterator_next(uc_vm_t *vm, uc_vm_insn_t insn,
 		return false;
 	}
 
-	uc_vm_stack_push(vm, ucv_string_new(iter->u.pos->k));
+	is_dict = (iter->table->equal_fn == uc_dict_equal);
+
+	if (is_dict)
+		uc_vm_stack_push(vm, ucv_get((uc_value_t *)iter->u.pos->k));
+	else
+		uc_vm_stack_push(vm, ucv_string_new((char *)iter->u.pos->k));
 
 	if (insn == I_NEXTKV)
 		uc_vm_stack_push(vm, ucv_get((uc_value_t *)iter->u.pos->v));
@@ -2597,7 +2648,9 @@ uc_vm_insn_delete(uc_vm_t *vm, uc_vm_insn_t insn)
 	switch (ucv_type(v)) {
 	case UC_OBJECT:
 		if (assert_mutable_value(vm, v)) {
-			rv = ucv_key_delete(vm, v, k);
+			rv = ucv_is_dict(v)
+				? ucv_dict_delete(vm, v, k)
+				: ucv_key_delete(vm, v, k);
 			uc_vm_stack_push(vm, ucv_boolean_new(rv));
 		}
 


### PR DESCRIPTION
## Summary

Introduce a new **dict** data structure type that extends regular ucode objects by allowing **arbitrary value keys** instead of being limited to string keys.

## Motivation

Regular ucode objects use null-terminated strings as keys, which is the standard JSON/JavaScript object model. However, there are use cases where you need a map-like structure with non-string keys — e.g., using booleans, numbers, or even other objects as keys. The new `dict` type fills this gap.

## Key Uniqueness Semantics

Key uniqueness follows `uc_uniq()` semantics:

- **Scalars** (null, bool, int, double, string): compared by **value equality**
- **Non-scalars** (arrays, objects, resources, closures): compared by **pointer equality**
- **NaN doubles**: treated as equal for hashing purposes

This means two distinct array instances with identical contents are treated as *different* keys, while two integer values `42` and `42` are the *same* key.

## Implementation Details

### Dict Detection

Dicts reuse the existing `UC_OBJECT` type internally and are distinguished from regular objects by their hash table's `equal_fn` function pointer, set to the sentinel `uc_dict_equal`. This preserves `ext_flag` for `is_constant` semantics without requiring a new uc_type enum value.

### Hash Table

The dict hash table uses a custom hash function (`uc_dict_hash`) and equality function (`uc_dict_equal`) that operate on `uc_value_t*` keys:

- For scalars, the hash is computed from the value bytes
- For non-scalars, the hash is computed from the pointer address
- The entry destructor (`ucv_free_dict_entry`) releases references to both key and value `uc_value_t` objects

### GC Integration

Dict keys are `uc_value_t*` pointers that must be traced during garbage collection. The `ucv_gc_mark()` function now checks `ucv_is_dict()` and marks both keys and values for dict objects.

### Prototype Chain

Prototype chain lookup works across dict/object boundaries:

- When looking up a key in a dict and it's not found, the prototype chain is walked
- If the prototype is a regular object, the dict key is converted to a string for lookup
- If the prototype is a dict, the value key is used directly

### Spread Operator

- **Dict → Object**: value keys are converted to strings via `ucv_to_string()`
- **Object → Dict**: string keys become string-value keys
- **Dict → Dict**: value keys are copied as-is
- **Array → Dict/Object**: handled correctly in both directions

## New API

### `dict()` Constructor

```ucode
let d = dict();                    // empty dict
let d = dict({ a: 1, b: 2 });      // from object
let d = dict([ 10, 20, 30 ]);      // from array (indices become int keys)
let d = dict(other_dict);          // from another dict
```

### `ucv_is_dict()` Helper

Inline function in `types.h` for runtime dict detection.

### `ucv_dict_*()` Functions

| Function | Description |
|---|---|
| `ucv_dict_new()` | Create a new dict, optionally from a source |
| `ucv_dict_get()` | Get a value by value key (with proto chain lookup) |
| `ucv_dict_set()` | Set a value by value key |
| `ucv_dict_delete()` | Delete a key from a dict |
| `ucv_dict_length()` | Get the number of entries |

### `ucv_dict_foreach()` Macro

Iteration macro for traversing dict entries, yielding `uc_value_t*` keys and values.

## Modified Builtins

The following stdlib functions now handle dicts transparently:

- **`length()`** — returns entry count for dicts
- **`keys()`** — returns actual value keys (not strings) for dicts
- **`values()`** — returns values for dicts
- **`exists()`** — checks key existence using value semantics for dicts

## VM Integration

The VM instructions `LOAD_VAL`, `PEEK_VAL`, `STORE_VAL`, `UPDATE_VAL`, `SOBJ`, `MOBJ`, `I_NEXT/I_NEXTKV`, and `DELETE` are all updated to dispatch to dict-specific functions when `ucv_is_dict()` returns true.

## Testing

Comprehensive test suite in `tests/custom/03_stdlib/69_dict` covering:

- Empty dict creation
- Initialization from objects, arrays, and dicts
- All scalar key types (bool, int, float, null, string)
- NaN key equality
- Array/object key pointer equality semantics
- Key updates, deletions
- `keys()`, `values()`, `exists()`, `length()` integration
- Spread operator (dict↔object, dict↔dict)
- `for...in` iteration with value keys
- Prototype chain (dict→object and dict→dict)
- Increment/decrement operations
- GC stress test (1000 dicts × 50 keys, valgrind-clean)
