### PR TITLE
include: reserve the unused shorthand to ucode's own build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 
-add_compile_definitions( _GNU_SOURCE )
+add_compile_definitions( _GNU_SOURCE UCODE_INTERNAL )
 add_compile_options(
   -Wall
   -Werror

--- a/include/ucode/util.h
+++ b/include/ucode/util.h
@@ -30,15 +30,23 @@
 #define __hidden __attribute__((visibility("hidden")))
 #endif
 
-#ifndef unused
-# if defined(__GNUC__) || defined(__clang__)
-#  define unused __attribute__((unused))
+/*
+ * Inside GNU attribute syntax `unused` is a plain identifier, so a macro of
+ * that name rewrites the `__attribute__((unused))` of every header a
+ * consumer includes after this one. The shorthand is therefore reserved to
+ * ucode's own translation units, which are built with UCODE_INTERNAL.
+ */
+#ifdef UCODE_INTERNAL
+# ifndef unused
+#  if defined(__GNUC__) || defined(__clang__)
+#   define unused __attribute__((unused))
+#  endif
 # endif
 #endif
 
 #ifndef localfunc
 # if defined(__GNUC__) || defined(__clang__)
-#  define localfunc static unused __attribute__((noinline))
+#  define localfunc static __attribute__((__unused__, __noinline__))
 # else
 #  define localfunc static inline
 # endif


### PR DESCRIPTION
abb80c6 ("include: add `unused` macro"). breaks anything that also uses "unused" such as openssl. this patch adds a safeguard causing the macro to only be visible to ucode internally and not leaking into other code it is linked against.