### PR TITLE
compiler, vm: implement tail call optimization

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -129,6 +129,7 @@ uc_compiler_init(uc_compiler_t *compiler, const char *name, uc_source_t *source,
 	uc_function_t *fn;
 
 	compiler->scope_depth = 0;
+	compiler->try_depth = 0;
 
 	compiler->program = program;
 	compiler->function = uc_program_function_new(program, name, source, srcpos);
@@ -144,6 +145,7 @@ uc_compiler_init(uc_compiler_t *compiler, const char *name, uc_source_t *source,
 	compiler->parent = NULL;
 
 	compiler->current_srcpos = srcpos;
+	compiler->tailcall_off = SIZE_MAX;
 
 	fn = (uc_function_t *)compiler->function;
 	fn->strict = strict;
@@ -580,6 +582,54 @@ uc_compiler_set_u32(uc_compiler_t *compiler, size_t off, uint32_t n)
 	chunk->entries[off + 1] = (n / 0x10000) % 0x100;
 	chunk->entries[off + 2] = (n / 0x100) % 0x100;
 	chunk->entries[off + 3] = n % 0x100;
+}
+
+/* Returns true if the most recently emitted instruction sequence is a function
+ * call whose operands end exactly at the current end of the chunk, i.e. the call
+ * is the last thing compiled before the upcoming return. */
+static bool
+uc_compiler_last_insn_is_tailcall(uc_compiler_t *compiler)
+{
+	/* tailcall_off records the chunk end right after the last emitted call's
+	 * operands; it is a tail call candidate only if nothing has been compiled
+	 * since, so it must equal the current chunk end */
+	return compiler->tailcall_off ==
+		uc_compiler_current_chunk(compiler)->count;
+}
+
+/* Invoking a function in tail position allows the VM to reuse the current call
+ * frame for the callee, which permits unbounded tail recursion.
+ *
+ * A function call in return position is marked by emitting a 0x00 marker byte
+ * immediately after the enclosing I_RETURN. The VM recognizes a call whose
+ * operands are followed by I_RETURN + marker as a tail call and reuses the
+ * current frame for the callee.
+ *
+ * The marker is placed after the return so that neither VM ever executes it:
+ * older VMs return (and unwind) before reaching it, and the optimized VM jumps
+ * to the callee at the call site. It is therefore pure data, and the emitted
+ * bytecode remains compatible with interpreters predating tail call
+ * optimization.
+ *
+ * uc_compiler_tailcall_pending() must be called before the I_RETURN is emitted
+ * (while the call is still the last instruction); if it returns true, the
+ * caller must emit the I_RETURN and then uc_compiler_emit_tailcall_marker(). */
+
+static bool
+uc_compiler_tailcall_pending(uc_compiler_t *compiler)
+{
+	/* an enclosing try block might need to catch exceptions raised by the
+	 * invoked function, which requires the current frame to stay in place */
+	if (compiler->try_depth > 0)
+		return false;
+
+	return uc_compiler_last_insn_is_tailcall(compiler);
+}
+
+static void
+uc_compiler_emit_tailcall_marker(uc_compiler_t *compiler)
+{
+	uc_chunk_add(uc_compiler_current_chunk(compiler), 0x00, 0);
 }
 
 static size_t
@@ -1519,7 +1569,14 @@ uc_compiler_compile_arrowfn(uc_compiler_t *compiler, uc_value_t *args, bool rest
 	}
 	else {
 		uc_compiler_parse_precedence(&fncompiler, P_ASSIGN);
+
+		/* invoke a function call in tail position to avoid growing the stack */
+		bool tailcall = uc_compiler_tailcall_pending(&fncompiler);
+
 		uc_compiler_emit_insn(&fncompiler, 0, I_RETURN);
+
+		if (tailcall)
+			uc_compiler_emit_tailcall_marker(&fncompiler);
 	}
 
 	/* emit load instruction for function value */
@@ -1764,6 +1821,10 @@ uc_compiler_compile_call(uc_compiler_t *compiler)
 		uc_compiler_emit_u16(compiler, 0, nargs - spreads.entries[i] - 1);
 
 	uc_vector_clear(&spreads);
+
+	/* remember the chunk end right after the invocation's operands for potential
+	 * tail call optimization */
+	compiler->tailcall_off = uc_compiler_current_chunk(compiler)->count;
 
 	compiler->patchlist->depth = uc_compiler_current_chunk(compiler)->count;
 }
@@ -3153,6 +3214,10 @@ uc_compiler_compile_try(uc_compiler_t *compiler)
 	/* Try block ------------------------------------------------------------ */
 	uc_compiler_enter_scope(compiler);
 
+	/* while compiling the protected block, tail calls are avoided since the
+	 * current frame must be kept around to catch callee exceptions */
+	compiler->try_depth++;
+
 	uc_compiler_parse_consume(compiler, TK_LBRACE);
 
 	while (!uc_compiler_parse_check(compiler, TK_RBRACE) &&
@@ -3160,6 +3225,8 @@ uc_compiler_compile_try(uc_compiler_t *compiler)
 		uc_compiler_compile_declaration(compiler);
 
 	uc_compiler_parse_consume(compiler, TK_RBRACE);
+
+	compiler->try_depth--;
 
 	uc_compiler_leave_scope(compiler);
 
@@ -3266,7 +3333,13 @@ uc_compiler_compile_return(uc_compiler_t *compiler)
 	else
 		uc_chunk_pop(chunk);
 
+	/* invoke a function call in tail position to avoid growing the stack */
+	bool tailcall = uc_compiler_tailcall_pending(compiler);
+
 	uc_compiler_emit_insn(compiler, compiler->parser->prev.pos, I_RETURN);
+
+	if (tailcall)
+		uc_compiler_emit_tailcall_marker(compiler);
 }
 
 static void
@@ -4088,7 +4161,15 @@ uc_compile_from_source(uc_parse_config_t *config, uc_source_t *source, uc_progra
 
 	if (!compiler.function->module && last_statement_type == TK_SCOL) {
 		uc_chunk_pop(uc_compiler_current_chunk(&compiler));
+
+		/* invoke a trailing call statement in tail position */
+		bool tailcall = uc_compiler_tailcall_pending(&compiler);
+
 		uc_compiler_emit_insn(&compiler, 0, I_RETURN);
+
+		if (tailcall)
+			uc_compiler_emit_tailcall_marker(&compiler);
+
 		last_statement_type = TK_RETURN;
 	}
 

--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -114,7 +114,7 @@ typedef struct uc_compiler {
 	uc_function_t *function;
 	uc_parser_t *parser;
 	uc_program_t *program;
-	size_t scope_depth, current_srcpos, last_insn;
+	size_t scope_depth, current_srcpos, last_insn, try_depth, tailcall_off;
 } uc_compiler_t;
 
 typedef struct {

--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -325,6 +325,11 @@ typedef struct {
 	size_t stackframe;
 	uc_value_t *ctx;
 	bool mcall, strict;
+	/* number of tail calls that reused this frame, i.e. the number of call
+	 * frames collapsed into it by tail call optimization. stored as a uint16_t
+	 * so it fits in the struct's trailing padding and does not change its size,
+	 * preserving the ABI; the count saturates at 0xffff rather than wrapping */
+	uint16_t tco;
 } uc_callframe_t;
 
 uc_declare_vector(uc_callframes_t, uc_callframe_t);

--- a/lib.c
+++ b/lib.c
@@ -171,7 +171,7 @@ uc_source_context_format(uc_stringbuf_t *buf, uc_source_t *src, size_t off, bool
 bool
 uc_error_context_format(uc_stringbuf_t *buf, uc_source_t *src, uc_value_t *stacktrace, size_t off)
 {
-	uc_value_t *e, *fn, *file, *line, *byte;
+	uc_value_t *e, *fn, *file, *line, *byte, *tco;
 	const char *path;
 	size_t idx;
 
@@ -179,6 +179,7 @@ uc_error_context_format(uc_stringbuf_t *buf, uc_source_t *src, uc_value_t *stack
 		e = ucv_array_get(stacktrace, idx);
 		fn = ucv_object_get(e, "function", NULL);
 		file = ucv_object_get(e, "filename", NULL);
+		tco = ucv_object_get(e, "tco", NULL);
 
 		if (idx == 0) {
 			path = (file && strcmp(ucv_string_get(file), "[stdin]"))
@@ -213,6 +214,13 @@ uc_error_context_format(uc_stringbuf_t *buf, uc_source_t *src, uc_value_t *stack
 			else
 				ucv_stringbuf_append(buf, "[C])\n");
 		}
+
+		/* indicate the call frames collapsed into this one by tail call
+		 * optimization, which are absent from the trace */
+		if (tco)
+			ucv_stringbuf_printf(buf,
+				"  (%" PRId64 " tail call frames omitted)\n",
+				ucv_int64_get(tco));
 	}
 
 	return uc_source_context_format(buf, src, off, false);

--- a/tests/custom/02_runtime/09_tail_calls
+++ b/tests/custom/02_runtime/09_tail_calls
@@ -1,0 +1,333 @@
+Testing tail call optimization of function invocations in return position.
+
+
+1. Testing unbounded direct tail recursion.
+
+-- Expect stdout --
+done
+-- End --
+
+-- Testcase --
+{%
+	function count(n) {
+		if (n === 0)
+			return "done";
+
+		return count(n - 1);
+	}
+
+	print(count(200000), "\n");
+%}
+-- End --
+
+
+2. Testing tail recursive accumulator and mutual recursion.
+
+-- Expect stdout --
+125250
+even
+even
+-- End --
+
+-- Testcase --
+{%
+	function sum(n, acc) {
+		return n === 0 ? acc : sum(n - 1, acc + n);
+	}
+
+	let isEven, isOdd;
+
+	isEven = (n) => n === 0 ? true : isOdd(n - 1);
+	isOdd = (n) => n === 0 ? false : isEven(n - 1);
+
+	print(sum(500, 0), "\n");
+	print(isEven(100000) ? "even" : "odd", "\n");
+	print(isOdd(100000) ? "odd" : "even", "\n");
+%}
+-- End --
+
+
+3. Testing method invocation tail calls preserving the receiver.
+
+-- Expect stdout --
+called 4 times, counter=12
+-- End --
+
+-- Testcase --
+{%
+	let o = {
+		count: 0,
+		counter: 0,
+		inc(n) {
+			this.count++;
+			this.counter += n;
+
+			if (this.count < 4)
+				return this.inc(3);
+
+			return `called ${this.count} times, counter=${this.counter}`;
+		}
+	};
+
+	print(o.inc(3), "\n");
+%}
+-- End --
+
+
+4. Testing tail calls in conditional and logical expressions.
+
+-- Expect stdout --
+yes no or and nullish y g -
+-- End --
+
+-- Testcase --
+{%
+	function id(x) {
+		return x;
+	}
+
+	function pick(n) {
+		return n ? id("yes") : id("no");
+	}
+
+	function logical(n) {
+		return n || id("or");
+	}
+
+	function coalesce(n) {
+		return n ?? id("nullish");
+	}
+
+	function optional(fn) {
+		return fn?.("g");
+	}
+
+	print(pick(1), " ", pick(0), " ",
+	      logical(null), " ", logical("and"), " ",
+	      coalesce(null), " ", coalesce("y"), " ",
+	      optional(id), " ", optional(null) ?? "-",
+	"\n");
+%}
+-- End --
+
+
+5. Testing tail calls with spread, missing and excess arguments.
+
+-- Expect stdout --
+6 12 0 nob 5
+-- End --
+
+-- Testcase --
+{%
+	function total(...vals) {
+		let r = 0;
+
+		for (let v in vals)
+			r += v;
+
+		return r;
+	}
+
+	function defaults(a, b, c) {
+		return b ?? "nob";
+	}
+
+	function nargs(...vals) {
+		return length(vals);
+	}
+
+	function spread(arr, n) {
+		return n === 0 ? total(...arr) : spread(arr, n - 1);
+	}
+
+	function mixed(arr, n) {
+		return n === 0 ? total(1, ...arr, 6) : mixed(arr, n - 1);
+	}
+
+	function empty(n) {
+		return n === 0 ? total() : empty(n - 1);
+	}
+
+	function missing(n) {
+		return n === 0 ? defaults() : missing(n - 1);
+	}
+
+	function excess(n) {
+		return n === 0 ? nargs(1, 2, 3, 4, 5) : excess(n - 1);
+	}
+
+	print(spread([1, 2, 3], 10000), " ",
+	      mixed([2, 3], 10000), " ",
+	      empty(10000), " ",
+	      missing(10000), " ",
+	      excess(10000),
+	"\n");
+%}
+-- End --
+
+
+6. Testing that tail calls do not disturb enclosing local variables.
+
+-- Expect stdout --
+T1000:1 { "tag": "T1000" }
+-- End --
+
+-- Testcase --
+{%
+	function inner(o, arr, n) {
+		if (n === 0)
+			return `${o.tag}:${arr[1]} ${o}`;
+
+		arr[1] = n;
+
+		return inner(o, arr, n - 1);
+	}
+
+	function outer(n) {
+		let obj = { tag: `T${n}` };
+		let list = [n];
+
+		return inner(obj, list, 5);
+	}
+
+	print(outer(1000), "\n");
+%}
+-- End --
+
+
+7. Testing tail calls of closures over locals of the replaced frame.
+
+-- Expect stdout --
+#7 #100000 done
+-- End --
+
+-- Testcase --
+{%
+	function mk(n) {
+		let label = `#${n}`;
+		let walk;
+
+		walk = (k) => k === 0 ? label : walk(k - 1);
+
+		return n === 0 ? "done" : walk(n);
+	}
+
+	print(mk(7), " ", mk(100000), " ", mk(0), "\n");
+%}
+-- End --
+
+
+8. Testing tail calls through callback invocation.
+
+-- Expect stdout --
+applied deep-done
+-- End --
+
+-- Testcase --
+{%
+	function apply(cb, n) {
+		return cb(n);
+	}
+
+	function repeater(n) {
+		return apply((x) => x === 0 ? "applied" : repeater(x - 1), n);
+	}
+
+	function tramp(n, f) {
+		return n === 0 ? f() : tramp(n - 1, f);
+	}
+
+	print(repeater(50000), " ", tramp(50000, () => "deep-done"), "\n");
+%}
+-- End --
+
+
+9. Testing exceptions raised by tail called functions.
+
+-- Expect stdout --
+caught: boom in-try: recovered
+-- End --
+
+-- Testcase --
+{%
+	function fail() {
+		die("boom");
+	}
+
+	function deep(n) {
+		return n === 0 ? fail() : deep(n - 1);
+	}
+
+	function direct(n) {
+		return n === 0 ? die("nope") : direct(n - 1);
+	}
+
+	function recover(n) {
+		try {
+			return direct(n);
+		}
+		catch (e) {
+			return "recovered";
+		}
+	}
+
+	function intry(n) {
+		try {
+			return deep(n);
+		}
+		catch (e) {
+			return `caught: ${e.message} in-try: ${recover(n)}`;
+		}
+	}
+
+	print(intry(20000), "\n");
+%}
+-- End --
+
+
+10. Testing that non-tail invocations still hit the recursion limit.
+
+-- Expect stderr --
+Runtime error: Too much recursion
+In tailrec(), line 3, byte 11:
+  called from anonymous function ([stdin]:6:10)
+
+ `        tailrec();`
+  Near here ------^
+
+
+-- End --
+
+-- Testcase --
+{%
+	function tailrec() {
+		tailrec();
+	}
+
+	tailrec();
+%}
+-- End --
+
+
+11. Testing that calls contributing to an expression still hit the recursion limit.
+
+-- Expect stderr --
+Runtime error: Too much recursion
+In tailrec(), line 3, byte 18:
+  called from anonymous function ([stdin]:6:10)
+
+ `        return tailrec() + 1;`
+  Near here -------------^
+
+
+-- End --
+
+-- Testcase --
+{%
+	function tailrec() {
+		return tailrec() + 1;
+	}
+
+	tailrec();
+%}
+-- End --

--- a/vm.c
+++ b/vm.c
@@ -462,6 +462,10 @@ uc_vm_frame_dump(uc_vm_t *vm, uc_callframe_t *frame)
 	fprintf(stderr, "   |- ctx %s\n",
 		uc_vm_format_val(vm, frame->ctx));
 
+	if (frame->tco)
+		fprintf(stderr, "   |- tailcall (%u callframes omitted)\n",
+			frame->tco);
+
 	if (chunk) {
 		closure = frame->closure;
 		function = closure->function;
@@ -659,7 +663,9 @@ uc_vm_frame_reinit(uc_vm_t *vm, uc_closure_t *closure, uc_value_t *ctx,
 	vm->stack.count = blockdst + blocklen;
 
 	/* reinitialize the call frame in place; the receiver value of a method call
-	 * occupies the slot below the invoked function value */
+	 * occupies the slot below the invoked function value. the tco counter records
+	 * that this frame replaced the tail calling one, so stack traces can indicate
+	 * the collapsed frames */
 	frame->stackframe = blockdst + (mcall ? 1 : 0);
 	frame->cfunction = NULL;
 	frame->closure = closure;
@@ -667,6 +673,11 @@ uc_vm_frame_reinit(uc_vm_t *vm, uc_closure_t *closure, uc_value_t *ctx,
 	frame->ip = closure->function->chunk.entries;
 	frame->mcall = mcall;
 	frame->strict = closure->function->strict;
+
+	/* saturate rather than wrap, so the count stays a valid (if capped) number
+	 * of omitted frames */
+	if (frame->tco < 0xffff)
+		frame->tco++;
 
 	if (vm->trace)
 		uc_vm_frame_dump(vm, frame);
@@ -1105,6 +1116,11 @@ uc_vm_capture_stacktrace(uc_vm_t *vm, size_t i)
 
 			ucv_object_add(entry, "function", ucv_string_new(name));
 		}
+
+		/* record the number of call frames collapsed into this one by tail call
+		 * optimization, so consumers can indicate the missing frames */
+		if (frame->tco)
+			ucv_object_add(entry, "tco", ucv_int64_new(frame->tco));
 
 		if (!ucv_is_equal(last, entry)) {
 			ucv_array_push(stacktrace, entry);

--- a/vm.c
+++ b/vm.c
@@ -122,6 +122,9 @@ static uc_value_t *
 uc_vm_callframe_pop(uc_vm_t *vm);
 
 static void
+uc_vm_close_upvals(uc_vm_t *vm, size_t slot);
+
+static void
 uc_vm_reset_callframes(uc_vm_t *vm)
 {
 	while (vm->callframes.count > 0)
@@ -601,8 +604,81 @@ uc_vm_call_native(uc_vm_t *vm, uc_value_t *ctx, uc_cfunction_t *fptr, bool mcall
 		ucv_put(res);
 }
 
+/* Replaces the current call frame by an invocation frame for the given closure,
+ * reusing the stack slots formerly occupied by the current frame.
+ *
+ * Since neither the call frame vector nor the value stack grow when invoking the
+ * callee, this allows unbounded tail recursion.
+ *
+ * On entry, the stack holds the invoked function value and its arguments at the
+ * top, optionally preceded by the receiver value of a method invocation. */
+static void
+uc_vm_frame_reinit(uc_vm_t *vm, uc_closure_t *closure, uc_value_t *ctx,
+                   bool mcall, size_t nargs)
+{
+	size_t i, blocksrc, blockdst, blocklen, blockofs;
+	uc_callframe_t *frame = uc_vm_current_frame(vm);
+	uc_value_t *oldclosure, *oldctx, *val;
+
+	/* the slot the invoking code expects the eventual return value at, which is
+	 * the slot of the current frame's function value, or - for method calls - of
+	 * the receiver value immediately below it */
+	blockdst = frame->stackframe - (frame->mcall ? 1 : 0);
+
+	/* number of stack slots occupied by the receiver, function and arguments */
+	blocklen = nargs + 1 + (mcall ? 1 : 0);
+
+	/* slot of the invoked function value, or of the receiver value preceding it */
+	blocksrc = vm->stack.count - blocklen;
+
+	/* the value block is relocated towards the start of the stack, so the slots
+	 * it occupies are always read before being overwritten */
+	blockofs = blocksrc - blockdst;
+
+	/* close upvalues referring to the current frame's stack slots before overwriting them */
+	uc_vm_close_upvals(vm, frame->stackframe);
+
+	/* remember the value references owned by the current frame */
+	oldclosure = frame->closure ? &frame->closure->header : NULL;
+	oldctx = frame->ctx;
+
+	/* move receiver, function value and arguments down into the slots of the frame
+	 * being replaced, releasing the local variable, temporary and receiver values
+	 * formerly held by them and clearing stale slots left above the new frame */
+	for (i = blockdst; i < vm->stack.count; i++) {
+		val = (i - blockdst < blocklen) ? vm->stack.entries[i + blockofs] : NULL;
+
+		/* the slot holds a value owned by the current frame unless it is part of
+		 * the value block being relocated */
+		if (i < blocksrc)
+			ucv_put(vm->stack.entries[i]);
+
+		vm->stack.entries[i] = val;
+	}
+
+	vm->stack.count = blockdst + blocklen;
+
+	/* reinitialize the call frame in place; the receiver value of a method call
+	 * occupies the slot below the invoked function value */
+	frame->stackframe = blockdst + (mcall ? 1 : 0);
+	frame->cfunction = NULL;
+	frame->closure = closure;
+	frame->ctx = ctx;
+	frame->ip = closure->function->chunk.entries;
+	frame->mcall = mcall;
+	frame->strict = closure->function->strict;
+
+	if (vm->trace)
+		uc_vm_frame_dump(vm, frame);
+
+	/* release the references formerly owned by the current frame */
+	ucv_put(oldclosure);
+	ucv_put(oldctx);
+}
+
 static bool
-uc_vm_call_function(uc_vm_t *vm, uc_value_t *ctx, uc_value_t *fno, bool mcall, size_t argspec)
+uc_vm_call_function(uc_vm_t *vm, uc_value_t *ctx, uc_value_t *fno, bool mcall,
+                   size_t argspec, bool tail)
 {
 	size_t i, j, stackoff, nargs = argspec & 0xffff;
 	size_t nspreads = (argspec >> 16) & 0x7fff;
@@ -613,8 +689,8 @@ uc_vm_call_function(uc_vm_t *vm, uc_value_t *ctx, uc_value_t *fno, bool mcall, s
 	uint16_t slot, tmp;
 	char *s;
 
-	/* XXX: make dependent on stack size */
-	if (vm->callframes.count >= 1000) {
+	/* a tail invocation reuses the current frame, so it never grows the stack */
+	if (!tail && vm->callframes.count >= 1000) {
 		uc_vm_raise_exception(vm, EXCEPTION_RUNTIME, "Too much recursion");
 		ucv_put(ctx);
 		ucv_put(fno);
@@ -679,7 +755,9 @@ uc_vm_call_function(uc_vm_t *vm, uc_value_t *ctx, uc_value_t *fno, bool mcall, s
 		nargs = vm->stack.count - stackoff - 1;
 	}
 
-	/* is a native function */
+	/* is a native function; such functions are always invoked in a fresh frame,
+	 * even when requested as tail call, since the foreign code may rely on the
+	 * stack layout of an ordinary invocation */
 	if (ucv_type(fno) == UC_CFUNCTION) {
 		uc_vm_call_native(vm, ctx, (uc_cfunction_t *)fno, mcall, nargs);
 
@@ -727,6 +805,15 @@ uc_vm_call_function(uc_vm_t *vm, uc_value_t *ctx, uc_value_t *fno, bool mcall, s
 			for (i = function->nargs; i < nargs; i++)
 				ucv_put(uc_vm_stack_pop(vm));
 		}
+	}
+
+	/* tail call: reuse the current call frame instead of pushing a new one. The
+	 * number of values above the invoked function may differ from the encoded
+	 * argument count due to spread operations or excess argument handling */
+	if (tail) {
+		uc_vm_frame_reinit(vm, closure, ctx, mcall, vm->stack.count - stackoff - 1);
+
+		return true;
 	}
 
 	frame = uc_vector_push(&vm->callframes, {
@@ -2542,19 +2629,29 @@ uc_vm_insn_close_upval(uc_vm_t *vm, uc_vm_insn_t insn)
 }
 
 static void
-uc_vm_insn_call(uc_vm_t *vm, uc_vm_insn_t insn)
+uc_vm_insn_call(uc_vm_t *vm)
 {
 	bool mcall = (vm->arg.u32 & 0x80000000);
 	size_t nargs = (vm->arg.u32 & 0xffff);
+	size_t nspreads = (vm->arg.u32 >> 16) & 0x7fff;
+	uint8_t *ip = uc_vm_current_frame(vm)->ip + 2 * nspreads;
 	uc_value_t *fno = uc_vm_stack_peek(vm, nargs);
 	uc_value_t *ctx = NULL;
+	bool tail;
 
 	if (!ucv_is_arrowfn(fno))
 		ctx = mcall ? uc_vm_stack_peek(vm, nargs + 1) : NULL;
 	else if (vm->callframes.count > 0)
 		ctx = uc_vm_current_frame(vm)->ctx;
 
-	uc_vm_call_function(vm, ucv_get(ctx), ucv_get(fno), mcall, vm->arg.u32);
+	/* a tail call is indicated by a 0x00 marker that the compiler emits
+	 * immediately after the enclosing I_RETURN. ip points just past the call's
+	 * operand span, so ip[0] is the I_RETURN and ip[1] the marker. Neither VM
+	 * executes the marker: older VMs return before reaching it, and this VM
+	 * jumps to the callee at the call site. */
+	tail = (ip[0] == I_RETURN) && (ip[1] == 0x00);
+
+	uc_vm_call_function(vm, ucv_get(ctx), ucv_get(fno), mcall, vm->arg.u32, tail);
 }
 
 static void
@@ -3100,7 +3197,7 @@ uc_vm_execute_chunk(uc_vm_t *vm)
 			break;
 
 		case I_CALL:
-			uc_vm_insn_call(vm, insn);
+			uc_vm_insn_call(vm);
 			break;
 
 		case I_RETURN:
@@ -3245,7 +3342,7 @@ uc_vm_call(uc_vm_t *vm, bool mcall, size_t nargs)
 
 	uc_vm_clear_exception(vm);
 
-	if (uc_vm_call_function(vm, ctx, fno, mcall, nargs & 0xffff)) {
+	if (uc_vm_call_function(vm, ctx, fno, mcall, nargs & 0xffff, false)) {
 		if (ucv_type(fno) != UC_CFUNCTION)
 			uc_vm_execute_chunk(vm);
 	}


### PR DESCRIPTION
Function invocations in tail position — where the call's result is returned directly and no further work happens in the current frame — are now executed by reusing the current call frame for the callee instead of pushing a new one. This allows tail-recursive functions to run to arbitrary depth without growing the call stack, and without tripping the "Too much recursion" limit.

## Optimized call sites

A call is treated as a tail call when its operand sequence is the last thing the enclosing body does before returning, covering:

- explicit `return f(...)` statements
- arrow function expression bodies (`f = (x) => g(x)`)
- the implicit return of the final expression statement of a script

This also includes calls nested inside conditional (`?:`), logical (`||`/`&&`), nullish coalescing (`??`) and optional-chaining expressions, as long as the whole expression is in return position.

## Deliberately not optimized

- Calls inside `try` blocks: the enclosing frame must stay in place so that exceptions raised by the callee can be caught by it.
- Statement-position trailing calls (a bare `f();` at the end of a body): the call's result is discarded, so the recursion guard still applies. This keeps accidentally unbounded recursion failing with "Too much recursion" instead of looping forever.
- Calls contributing to a larger expression (`return f() + 1`) are ordinary calls.
- Native (C) functions are always invoked in a fresh frame.

## Preserved semantics

- The receiver (`this`) of method invocations is carried over into the callee's frame.
- Open upvalues of the replaced frame are closed before its stack slots are reused, so closures over the caller's locals remain correct across tail calls.
- Local variables of the replaced frame are released when the frame is discarded; values that the caller still references (e.g. locals captured by the return expression) are unaffected.
- Argument handling (defaults, rest/spread, missing/excess arguments) is identical to ordinary calls.
- Exceptions raised by a tail-called function propagate to the nearest enclosing `catch` outside the tail position, with the replaced frames skipped as usual.
- The recursion limit continues to apply to all non-tail invocations, including the unbounded-recursion cases above.

## Tests

`tests/custom/02_runtime/09_tail_calls` covers: unbounded direct tail recursion (100k+ depth), tail-recursive accumulators and mutual recursion, method tail calls preserving the receiver, tail calls in conditional/logical/nullish/optional expressions, spread/missing/excess arguments, independence from enclosing locals, closures over locals of the replaced frame, tail calls through callback invocation, exception propagation through deep tail chains, and the recursion limit for non-tail and statement-position calls.
