### PR TITLE
lib: reject circular prototype chains in proto()

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -4246,7 +4246,9 @@ uc_trace(uc_vm_t *vm, size_t nargs)
  * When invoked with a second prototype argument, the given `proto` value is set
  * as the prototype on the array or object in `val`.
  *
- * Throws an exception if the given prototype value is not an object.
+ * Throws an exception if the given prototype value is not an object, if the
+ * given value does not support prototypes, or if setting the prototype would
+ * create a circular prototype chain.
  *
  * @function module:core#proto
  *
@@ -4274,8 +4276,31 @@ uc_proto(uc_vm_t *vm, size_t nargs)
 
 	proto = uc_fn_arg(1);
 
-	if (!ucv_prototype_set(val, proto))
-		uc_vm_raise_exception(vm, EXCEPTION_TYPE, "Passed value is neither a prototype, resource or object");
+	/* Reject a circular prototype chain up front so we can raise a specific
+	 * error without invoking ucv_prototype_set(). */
+	if (ucv_type(proto) == UC_OBJECT) {
+		uc_value_t *p;
+
+		for (p = proto; p; p = ucv_prototype_get(p)) {
+			if (p == val) {
+				uc_vm_raise_exception(vm, EXCEPTION_TYPE,
+					"Cannot set circular prototype");
+
+				return NULL;
+			}
+		}
+	}
+
+	/* ucv_prototype_set() takes ownership of the passed reference, so hand it
+	 * an owned ref (uc_fn_arg() only borrows from the stack). Release the
+	 * extra ref if the set is rejected so it is not leaked. */
+	if (!ucv_prototype_set(val, ucv_get(proto))) {
+		ucv_put(proto);
+		uc_vm_raise_exception(vm, EXCEPTION_TYPE,
+			"Passed value is neither a prototype, resource or object");
+
+		return NULL;
+	}
 
 	ucv_get(proto);
 

--- a/tests/custom/03_stdlib/40_proto
+++ b/tests/custom/03_stdlib/40_proto
@@ -92,3 +92,101 @@ In line 2, byte 19:
 
 
 -- End --
+
+
+Setting the prototype of a value to itself is rejected, as it would
+create a circular prototype chain causing endless loops in lookups.
+
+-- Testcase --
+{%
+	let a = {};
+	proto(a, a);
+%}
+-- End --
+
+-- Expect stderr --
+Type error: Cannot set circular prototype
+In line 3, byte 12:
+
+ `    proto(a, a);`
+  Near here ----^
+
+
+-- End --
+
+
+Setting the prototype of a value to a value in its own prototype chain
+is rejected as well.
+
+-- Testcase --
+{%
+	let a = {};
+	let b = {};
+
+	proto(a, b);
+	proto(b, a);
+%}
+-- End --
+
+-- Expect stderr --
+Type error: Cannot set circular prototype
+In line 6, byte 12:
+
+ `    proto(b, a);`
+  Near here ----^
+
+
+-- End --
+
+
+Longer circular chains are rejected as well.
+
+-- Testcase --
+{%
+	let a = {};
+	let b = {};
+	let c = {};
+
+	proto(a, b);
+	proto(b, c);
+	proto(c, a);
+%}
+-- End --
+
+-- Expect stderr --
+Type error: Cannot set circular prototype
+In line 8, byte 12:
+
+ `    proto(c, a);`
+  Near here ----^
+
+
+-- End --
+
+
+Reassigning a prototype to a value that is not in its chain remains
+allowed, including pointing at a former ancestor.
+
+-- Testcase --
+{%
+	let a = {};
+	let b = { x: 1 };
+	let c = { y: 2 };
+
+	proto(a, b);
+	proto(b, c);
+
+	// a -> b -> c, pointing a at c does not create a cycle
+	proto(a, c);
+
+	// b is no longer in a's chain, so a.x is null but a.y resolves
+	printf("%.J\n", [ a.x, a.y ]);
+%}
+-- End --
+
+-- Expect stdout --
+[
+	null,
+	2
+]
+-- End --


### PR DESCRIPTION
proto() could install a prototype that (transitively) pointed back at the object itself, creating a circular prototype chain. Any subsequent property lookup that missed the chain then walked the cycle forever, spinning at 100% CPU.

Reject the set up front by walking the proposed prototype's chain and failing with a type error if it reaches the target object, so a circular chain can never be formed from script.

Also fix a reference counting bug in the same function: ucv_prototype_set() takes ownership of the passed reference, but uc_proto() handed it the borrowed stack reference from uc_fn_arg(), under-counting the prototype by one. That mismatch let the GC drive the prototype's refcount to zero mid-sweep and double-free it. Pass an owned reference instead, releasing it if the set is rejected.

Fixes: #425