### PR TITLE
compiler: reject adjacent template literals

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -1862,7 +1862,21 @@ uc_compiler_compile_template(uc_compiler_t *compiler)
 	uc_compiler_emit_constant(compiler, compiler->parser->prev.pos, compiler->parser->prev.uv);
 
 	while (true) {
-		if (uc_compiler_parse_match(compiler, TK_TEMPLATE)) {
+		if (uc_compiler_parse_check(compiler, TK_TEMPLATE)) {
+			/* a TK_TEMPLATE token only continues the current literal when the
+			 * previous one was left open by a `${...}` placeholder, in which
+			 * case the lexer emits a TK_PLACEH token in between; two adjacent
+			 * TK_TEMPLATE tokens are separate literals and must be joined
+			 * with an explicit operator
+			 */
+			if (compiler->parser->prev.type == TK_TEMPLATE) {
+				uc_compiler_syntax_error(compiler, compiler->parser->curr.pos,
+					"Adjacent template literals are not implicitly concatenated");
+
+				return;
+			}
+
+			uc_compiler_parse_advance(compiler);
 			uc_compiler_emit_constant(compiler, compiler->parser->prev.pos, compiler->parser->prev.uv);
 			uc_compiler_emit_insn(compiler, 0, I_ADD);
 		}

--- a/tests/custom/00_syntax/27_template_literals
+++ b/tests/custom/00_syntax/27_template_literals
@@ -100,3 +100,23 @@ In line 2, byte 13:
 
 
 -- End --
+
+
+7. Adjacent template literals are not implicitly concatenated and require an
+   explicit operator between them.
+
+-- Testcase --
+{{
+	`foo` `bar`
+}}
+-- End --
+
+-- Expect stderr --
+Syntax error: Adjacent template literals are not implicitly concatenated
+In line 2, byte 8:
+
+ `    `foo` `bar``
+            ^-- Near here
+
+
+-- End --


### PR DESCRIPTION
Adjacent template string literals were implicitly concatenated, which is not part of the ECMAScript syntax that ucode is inspired by and was an unintentional side effect of the parser treating any subsequent TK_TEMPLATE token as a continuation of the current literal.

A TK_TEMPLATE token only continues the current literal when the previous one was left open by a ${...} placeholder, in which case the lexer emits a TK_PLACEH token in between; two adjacent TK_TEMPLATE tokens are therefore separate literals and are now rejected with a syntax error, requiring an explicit operator (e.g. '+') to combine them.

Fixes #368