### PR TITLE
linux/types.h: add 128-bit integer types

### DIFF
--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -8,6 +8,10 @@
 
 #include <linux/posix_types.h>
 
+#ifdef __SIZEOF_INT128__
+typedef __signed__ __int128 __s128 __attribute__((aligned(16)));
+typedef unsigned __int128 __u128 __attribute__((aligned(16)));
+#endif
 
 /*
  * Below are truly Linux-specific types that should never collide with


### PR DESCRIPTION
Add the `__s128` and `__u128` typedefs to the bundled `include/linux/types.h`, guarded by `__SIZEOF_INT128__`, as the kernel's uapi `linux/types.h` has defined them since Linux 6.5.

Linux 7.3 declares the arm64 fpsimd registers in `asm/sigcontext.h` as `__u128` (torvalds/linux@d4bf9e08d412289ae7c9072378bed238c0274c55). The bundled header sits on ucode's global include path and shadows the kernel's `linux/types.h`, so with glibc, whose `signal.h` pulls in `asm/sigcontext.h`, every translation unit that includes `signal.h` fails to compile on aarch64:

```
/usr/include/asm/sigcontext.h:81:9: error: unknown type name '__u128'; did you mean '__u32'?
   81 |         __u128 vregs[32];
```
