### PR TITLE
ubus: fix use-after-free / segfault on teardown of called objects

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -669,25 +669,6 @@ uc_ubus_error(uc_vm_t *vm, size_t nargs)
 	return rv;
 }
 
-static void
-uc_ubus_put_res(uc_value_t **rp)
-{
-	uc_value_t *res = *rp;
-	uc_resource_ext_t *ext;
-
-	*rp = NULL;
-
-	if (!res)
-		return;
-
-	ext = (uc_resource_ext_t *)res;
-	for (size_t i = 0; i < ext->uvcount; i++)
-		ucv_resource_value_set(res, i, NULL);
-
-	ucv_resource_persistent_set(res, false);
-	ucv_put(res);
-}
-
 enum {
 	CONN_RES_FD,
 	CONN_RES_CB,
@@ -726,6 +707,38 @@ enum {
 	SUB_RES_PATTERNS,
 	__SUB_RES_MAX,
 };
+
+/* Largest value slot count across all ubus resource types. Keep in sync
+ * with the largest __*_RES_MAX above; used to sweep a resource's value
+ * slots without needing to know its specific type. */
+enum {
+	UBUS_RES_MAX = __DEFER_RES_MAX
+};
+
+static void
+uc_ubus_put_res(uc_value_t **rp)
+{
+	uc_value_t *res = *rp;
+	size_t i;
+
+	*rp = NULL;
+
+	if (!res)
+		return;
+
+	/* drop the stored references (including a per-instance prototype, if
+	 * present) to break resource <-> closure reference cycles
+	 * deterministically, without waiting for a gc pass. The setter
+	 * ignores indexes beyond the resource's own value count, so it is
+	 * safe to sweep up to the largest ubus resource slot count. */
+	for (i = 0; i < UBUS_RES_MAX; i++)
+		ucv_resource_value_set(res, i, NULL);
+
+	ucv_resource_proto_set(res, NULL);
+
+	ucv_resource_persistent_set(res, false);
+	ucv_put(res);
+}
 
 static uc_value_t *
 blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const char **name);

--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -2444,8 +2444,23 @@ uc_ubus_handle_reply_common(struct ubus_context *ctx,
 	uc_value_t *reqobj, *res;
 	int rv;
 
-	/* allocate deferred method call context */
-	reqobj = ucv_resource_create_ex(vm, "ubus.request", (void **)&callctx, 1, sizeof(*callctx));
+	/* allocate deferred method call context.
+	 *
+	 * reqproto is a per-call object, so it must be stored in the request
+	 * resource's instance-specific prototype slot rather than being attached
+	 * to the shared "ubus.request" type prototype. The latter would leak the
+	 * per-call object (and everything it references) into the type prototype
+	 * for the lifetime of the VM, and cause a use-after-free at teardown:
+	 * uc_vm_free() releases the restype prototypes before the final GC, so
+	 * the shared type prototype is freed while still pointing at the
+	 * per-call object, which is then freed again as an unreachable value.
+	 *
+	 * ucv_resource_create_with_proto() takes ownership of reqproto and
+	 * chains it to the type prototype, so property lookup on reqobj still
+	 * falls through to the shared request methods.
+	 */
+	reqobj = ucv_resource_create_with_proto(vm, "ubus.request",
+			(void **)&callctx, 1, sizeof(*callctx), reqproto);
 
 	if (!callctx)
 		return UBUS_STATUS_UNKNOWN_ERROR;
@@ -2458,9 +2473,6 @@ uc_ubus_handle_reply_common(struct ubus_context *ctx,
 
 	/* fd is copied to deferred request. ensure it does not get closed early */
 	ubus_request_get_caller_fd(req);
-
-	if (reqproto)
-		ucv_prototype_set(ucv_prototype_get(reqobj), reqproto);
 
 	/* push object context, handler and request object onto stack */
 	uc_vm_stack_push(vm, ucv_get(this));

--- a/types.c
+++ b/types.c
@@ -2519,7 +2519,7 @@ ucv_key_to_index(uc_value_t *val)
 uc_value_t *
 ucv_key_get(uc_vm_t *vm, uc_value_t *scope, uc_value_t *key)
 {
-	uc_value_t *o, *v = NULL;
+	uc_value_t *o, *v = NULL, *inst_proto;
 	bool found = false;
 	uc_upvalref_t *ref;
 	int64_t idx;
@@ -2547,12 +2547,11 @@ ucv_key_get(uc_vm_t *vm, uc_value_t *scope, uc_value_t *key)
 			if (uv->ext_flag) {
 				uc_resource_ext_t *ext = (uc_resource_ext_t *)scope;
 
-				/* Check instance-specific proto first (set via ucv_resource_new_prototyped) */
-				if (ext->hasproto) {
-					uc_value_t *inst_proto = *(uc_value_t **)(ext + 1);
-					if (inst_proto) {
-						v = ucv_object_get(inst_proto, k ? k : ucv_string_get(key), &found);
-					}
+				/* Check instance-specific proto first (set via
+				 * ucv_resource_new_prototyped); returns NULL for resources
+				 * without an instance proto. */
+				if ((inst_proto = ucv_resource_proto_get(scope)) != NULL) {
+					v = ucv_object_get(inst_proto, k ? k : ucv_string_get(key), &found);
 				}
 
 				/* Then fall back to type prototype */


### PR DESCRIPTION
Fixes the ucode SIGSEGV seen when restarting wwand (and reproducible with a minimal script that publishes a ubus     
object, has it called, then exits).                                                                                  
                                                                                                                    
Root cause: the ubus request handler attached the per-call reqproto object (holding args/info) to the shared         
"ubus.request" resource-type prototype, because the request resource was created without an instance-proto slot:     
                                                                                                                    
```c                                                                                                                 
 ucv_prototype_set(ucv_prototype_get(reqobj), reqproto);                                                            
```                                                                                                                  
                                                                                                                    
That leaked the per-call object into the type prototype for the VM's lifetime, and at teardown uc_vm_free() releases 
restype prototypes before the final GC — freeing the shared type proto while it still pointed at the per-call        
object, which was then freed again as an unreachable value (UAF).                                                    
                                                                                                                    
Changes:                                                                                                             
- types: fix ucv_key_get() instance-proto lookup, which read the first word after the resource header (the start of  
 the data region) instead of the value array — a latent segfault for any hasproto resource with a non-trivial data  
 struct. Use ucv_resource_proto_get().                                                                              
- ubus: create the request resource via ucv_resource_create_with_proto(), storing reqproto in the per-instance proto 
 slot (chained to the type prototype) instead of mutating the shared type prototype.                                
- ubus: drop the per-instance proto slot in uc_ubus_put_res() (sweeping value slots through the public setter up to  
 UBUS_RES_MAX) so a released request resource doesn't retain its per-call proto.                                    
                                                                                                                    
Verification: minimal reproducer (publish + external ubus call + exit) is clean under valgrind before/after; full    
test suite passes.                                                                                                   
                                                                                                                    
Fixes #437